### PR TITLE
Fix of pathtool deleting path when moving ctrl points.

### DIFF
--- a/editor/path.js
+++ b/editor/path.js
@@ -550,7 +550,6 @@ svgedit.path.Segment.prototype.moveCtrl = function(num, dx, dy) {
 
         var pts = [cloneItem.x,cloneItem.y,
                 cloneItem.x1,cloneItem.y1, cloneItem.x2,cloneItem.y2];
-
         // end fix
 
 
@@ -584,8 +583,8 @@ svgedit.path.Path = function(elem) {
 svgedit.path.Path.prototype.init = function() {
 	// Hide all grips, etc
 
-//fixed, needed to work on all found elements, not just first
-$(svgedit.path.getGripContainer()).find('*').each( function() { $(this).attr('display', 'none') });
+	//fixed, needed to work on all found elements, not just first
+	$(svgedit.path.getGripContainer()).find('*').each( function() { $(this).attr('display', 'none') });
 
 	var segList = this.elem.pathSegList;
 	var len = segList.numberOfItems;

--- a/editor/path.js
+++ b/editor/path.js
@@ -15,7 +15,8 @@
 // 3) math.js
 // 4) svgutils.js
 
-(function() {'use strict';
+(function() {
+	//'use strict';
 
 if (!svgedit.path) {
 	svgedit.path = {};
@@ -139,7 +140,6 @@ svgedit.path.getPointFromGrip = function(pt, path) {
 svgedit.path.addPointGrip = function(index, x, y) {
 	// create the container of all the point grips
 	var pointGripContainer = svgedit.path.getGripContainer();
-
 	var pointGrip = svgedit.utilities.getElem('pathpointgrip_'+index);
 	// create it
 	if (!pointGrip) {
@@ -208,7 +208,6 @@ svgedit.path.addCtrlGrip = function(id) {
 svgedit.path.getCtrlLine = function(id) {
 	var ctrlLine = svgedit.utilities.getElem('ctrlLine_'+id);
 	if (ctrlLine) {return ctrlLine;}
-
 	ctrlLine = document.createElementNS(NS.SVG, 'line');
 	svgedit.utilities.assignAttributes(ctrlLine, {
 		'id': 'ctrlLine_'+id,
@@ -251,7 +250,6 @@ svgedit.path.getControlPoints = function(seg) {
 	var i;
 	for (i = 1; i < 3; i++) {
 		var id = index + 'c' + i;
-
 		var ctrlLine = cpt['c' + i + '_line'] = svgedit.path.getCtrlLine(id);
 
 		var pt = svgedit.path.getGripPt(seg, {x:item['x' + i], y:item['y' + i]});
@@ -283,6 +281,7 @@ svgedit.path.getControlPoints = function(seg) {
 // This replaces the segment at the given index. Type is given as number.
 svgedit.path.replacePathSeg = function(type, index, pts, elem) {
 	var path = elem || svgedit.path.path.elem;
+
 	var func = 'createSVGPathSeg' + pathFuncs[type];
 	var seg = path[func].apply(path, pts);
 
@@ -307,6 +306,7 @@ svgedit.path.replacePathSeg = function(type, index, pts, elem) {
 		}
 	}
 };
+
 
 svgedit.path.getSegSelector = function(seg, update) {
 	var index = seg.index;
@@ -345,7 +345,6 @@ svgedit.path.getSegSelector = function(seg, update) {
 			pts[i] = pt.x;
 			pts[i+1] = pt.y;
 		}
-
 		svgedit.path.replacePathSeg(seg.type, 1, pts, segLine);
 	}
 	return segLine;
@@ -477,12 +476,17 @@ svgedit.path.Segment.prototype.update = function(full) {
 svgedit.path.Segment.prototype.move = function(dx, dy) {
 	var cur_pts, item = this.item;
 
-	if (this.ctrlpts) {
-		cur_pts = [item.x += dx, item.y += dy, 
-			item.x1, item.y1, item.x2 += dx, item.y2 += dy];
-	} else {
-		cur_pts = [item.x += dx, item.y += dy];
-	}
+	// fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
+	var cloneItem = $.extend({}, item);
+
+        if(this.ctrlpts) {
+                var cur_pts = [cloneItem.x += dx, cloneItem.y += dy,
+                        cloneItem.x1, cloneItem.y1, cloneItem.x2 += dx, cloneItem.y2 += dy];
+        } else {
+                var cur_pts = [cloneItem.x += dx, cloneItem.y += dy];
+        }
+	//fix
+
 	svgedit.path.replacePathSeg(this.type, this.index, cur_pts);
 
 	if (this.next && this.next.ctrlpts) {
@@ -505,6 +509,9 @@ svgedit.path.Segment.prototype.move = function(dx, dy) {
 	if (this.next) {this.next.update(true);}
 };
 
+
+
+//HERE
 svgedit.path.Segment.prototype.setLinked = function(num) {
 	var seg, anum, pt;
 	if (num == 2) {
@@ -520,13 +527,16 @@ svgedit.path.Segment.prototype.setLinked = function(num) {
 	}
 
 	var item = seg.item;
+	// fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
+	var cloneItem = $.extend({}, item);
+        cloneItem['x' + anum ] = pt.x + (pt.x - this.item['x' + num]);
+        cloneItem['y' + anum ] = pt.y + (pt.y - this.item['y' + num]);
 
-	item['x' + anum] = pt.x + (pt.x - this.item['x' + num]);
-	item['y' + anum] = pt.y + (pt.y - this.item['y' + num]);
+        var pts = [cloneItem.x, cloneItem.y,
+              cloneItem.x1, cloneItem.y1,
+              cloneItem.x2, cloneItem.y2];
+        //end fix
 
-	var pts = [item.x, item.y,
-		item.x1, item.y1,
-		item.x2, item.y2];
 
 	svgedit.path.replacePathSeg(seg.type, seg.index, pts);
 	seg.update(true);
@@ -535,10 +545,16 @@ svgedit.path.Segment.prototype.setLinked = function(num) {
 svgedit.path.Segment.prototype.moveCtrl = function(num, dx, dy) {
 	var item = this.item;
 
-	item['x' + num] += dx;
-	item['y' + num] += dy;
+        // fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
+	var cloneItem = $.extend({}, item);
+        cloneItem['x' + num] += dx;
+        cloneItem['y' + num] += dy;
 
-	var pts = [item.x, item.y, item.x1, item.y1, item.x2, item.y2];
+        var pts = [cloneItem.x,cloneItem.y,
+                cloneItem.x1,cloneItem.y1, cloneItem.x2,cloneItem.y2];
+
+        // end fix
+
 
 	svgedit.path.replacePathSeg(this.type, this.index, pts);
 	this.update(true);
@@ -569,7 +585,10 @@ svgedit.path.Path = function(elem) {
 // Reset path data
 svgedit.path.Path.prototype.init = function() {
 	// Hide all grips, etc
-	$(svgedit.path.getGripContainer()).find('*').attr('display', 'none');
+
+//FIX ianb leaves last grip
+$(svgedit.path.getGripContainer()).find('*').each( function() { $(this).attr('display', 'none') });
+
 	var segList = this.elem.pathSegList;
 	var len = segList.numberOfItems;
 	this.segs = [];
@@ -699,6 +718,7 @@ svgedit.path.Path.prototype.deleteSeg = function(index) {
 	var pt;
 	if (seg.mate) {
 		// Make the next point be the "M" point
+
 		pt = [next.item.x, next.item.y];
 		svgedit.path.replacePathSeg(2, next.index, pt);
 

--- a/editor/path.js
+++ b/editor/path.js
@@ -309,7 +309,6 @@ svgedit.path.replacePathSeg = function(type, index, pts, elem) {
 	}
 };
 
-
 svgedit.path.getSegSelector = function(seg, update) {
 	var index = seg.index;
 	var segLine = svgedit.utilities.getElem('segline_' + index);
@@ -511,8 +510,6 @@ svgedit.path.Segment.prototype.move = function(dx, dy) {
 	this.update(true);
 	if (this.next) {this.next.update(true);}
 };
-
-
 
 svgedit.path.Segment.prototype.setLinked = function(num) {
 	var seg, anum, pt;

--- a/editor/path.js
+++ b/editor/path.js
@@ -15,8 +15,7 @@
 // 3) math.js
 // 4) svgutils.js
 
-(function() {
-	//'use strict';
+(function() {'use strict';
 
 if (!svgedit.path) {
 	svgedit.path = {};
@@ -511,7 +510,6 @@ svgedit.path.Segment.prototype.move = function(dx, dy) {
 
 
 
-//HERE
 svgedit.path.Segment.prototype.setLinked = function(num) {
 	var seg, anum, pt;
 	if (num == 2) {
@@ -586,7 +584,7 @@ svgedit.path.Path = function(elem) {
 svgedit.path.Path.prototype.init = function() {
 	// Hide all grips, etc
 
-//FIX ianb leaves last grip
+//fixed, needed to work on all found elements, not just first
 $(svgedit.path.getGripContainer()).find('*').each( function() { $(this).attr('display', 'none') });
 
 	var segList = this.elem.pathSegList;

--- a/editor/path.js
+++ b/editor/path.js
@@ -139,6 +139,7 @@ svgedit.path.getPointFromGrip = function(pt, path) {
 svgedit.path.addPointGrip = function(index, x, y) {
 	// create the container of all the point grips
 	var pointGripContainer = svgedit.path.getGripContainer();
+
 	var pointGrip = svgedit.utilities.getElem('pathpointgrip_'+index);
 	// create it
 	if (!pointGrip) {
@@ -207,6 +208,7 @@ svgedit.path.addCtrlGrip = function(id) {
 svgedit.path.getCtrlLine = function(id) {
 	var ctrlLine = svgedit.utilities.getElem('ctrlLine_'+id);
 	if (ctrlLine) {return ctrlLine;}
+
 	ctrlLine = document.createElementNS(NS.SVG, 'line');
 	svgedit.utilities.assignAttributes(ctrlLine, {
 		'id': 'ctrlLine_'+id,
@@ -249,6 +251,7 @@ svgedit.path.getControlPoints = function(seg) {
 	var i;
 	for (i = 1; i < 3; i++) {
 		var id = index + 'c' + i;
+
 		var ctrlLine = cpt['c' + i + '_line'] = svgedit.path.getCtrlLine(id);
 
 		var pt = svgedit.path.getGripPt(seg, {x:item['x' + i], y:item['y' + i]});
@@ -344,6 +347,7 @@ svgedit.path.getSegSelector = function(seg, update) {
 			pts[i] = pt.x;
 			pts[i+1] = pt.y;
 		}
+
 		svgedit.path.replacePathSeg(seg.type, 1, pts, segLine);
 	}
 	return segLine;
@@ -715,7 +719,6 @@ svgedit.path.Path.prototype.deleteSeg = function(index) {
 	var pt;
 	if (seg.mate) {
 		// Make the next point be the "M" point
-
 		pt = [next.item.x, next.item.y];
 		svgedit.path.replacePathSeg(2, next.index, pt);
 

--- a/editor/path.js
+++ b/editor/path.js
@@ -481,11 +481,11 @@ svgedit.path.Segment.prototype.move = function(dx, dy) {
 	// fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
 	var cloneItem = $.extend({}, item);
 
-        if(this.ctrlpts) {
-                var cur_pts = [cloneItem.x += dx, cloneItem.y += dy,
+        if (this.ctrlpts) {
+                cur_pts = [cloneItem.x += dx, cloneItem.y += dy,
                         cloneItem.x1, cloneItem.y1, cloneItem.x2 += dx, cloneItem.y2 += dy];
         } else {
-                var cur_pts = [cloneItem.x += dx, cloneItem.y += dy];
+                cur_pts = [cloneItem.x += dx, cloneItem.y += dy];
         }
 	//fix
 


### PR DESCRIPTION
Modifying 'item' seems to break some browsers, so copying the object and using that gets around it