### PR TITLE
Fix for import svg image leading to unattached dragtool

### DIFF
--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -4745,7 +4745,7 @@ TODOS
 			$('#zoom').SpinButton({ min: 0.001, max: 10000, step: 50, stepfunc: stepZoom, callback: changeZoom })
 				// Set default zoom
 				.val(svgCanvas.getZoom() * 100);
-
+///EDITED
 			$('#workarea').contextMenu({
 					menu: 'cmenu_canvas',
 					inSpeed: 0
@@ -4904,12 +4904,14 @@ TODOS
 						if (file.type.indexOf('svg') != -1) {
 							reader = new FileReader();
 							reader.onloadend = function(e) {
-								svgCanvas.importSvgString(e.target.result, true);
+								var newElement = svgCanvas.importSvgString(e.target.result, true);
 								svgCanvas.ungroupSelectedElement();
 								svgCanvas.ungroupSelectedElement();
 								svgCanvas.groupSelectedElements();
 								svgCanvas.alignSelectedElements('m', 'page');
 								svgCanvas.alignSelectedElements('c', 'page');
+								// highlight imported element, otherwise we get strange empty selectbox
+								svgCanvas.selectOnly([newElement]);
 								$('#dialog_box').hide();
 							};
 							reader.readAsText(file);

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -4745,7 +4745,7 @@ TODOS
 			$('#zoom').SpinButton({ min: 0.001, max: 10000, step: 50, stepfunc: stepZoom, callback: changeZoom })
 				// Set default zoom
 				.val(svgCanvas.getZoom() * 100);
-///EDITED
+
 			$('#workarea').contextMenu({
 					menu: 'cmenu_canvas',
 					inSpeed: 0

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -5083,7 +5083,8 @@ this.importSvgString = function(xmlString) {
 		return false;
 	}
 
-	return true;
+	// we want to return the element so we can automatically select it
+	return use_el;
 };
 
 // TODO(codedread): Move all layer/context functions in draw.js

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -4959,7 +4959,7 @@ this.setSvgString = function(xmlString) {
 // xmlString - The SVG as XML text.
 //
 // Returns:
-// This function returns false if the import was unsuccessful, true otherwise.
+// This function returns null if the import was unsuccessful, or the element otherwise.
 // TODO: 
 // * properly handle if namespace is introduced by imported content (must add to svgcontent
 // and update all prefixes in the imported node)
@@ -5080,7 +5080,7 @@ this.importSvgString = function(xmlString) {
 
 	} catch(e) {
 		console.log(e);
-		return false;
+		return null;
 	}
 
 	// we want to return the element so we can automatically select it


### PR DESCRIPTION
If you import an svg image, it loads it, but then the dragtool appears on its own, not connected to the newly imported element.

When the element is imported, it isn't known 'what' this element is, so the change is to make the method return the element, so we can then use it, to 'select it, once the load is complete.

I cannot see any other methods reliant on the return value of this (which previously returned true rather than the element).