### PR TITLE
Changed jQuery absolute link to HTTPS

### DIFF
--- a/editor/svg-editor.html
+++ b/editor/svg-editor.html
@@ -13,7 +13,7 @@
 <link rel="stylesheet" href="spinbtn/JQuerySpinBtn.css" type="text/css"/>
 <link rel="stylesheet" href="custom.css" type="text/css"/>
 <!--{if jquery_release}>
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 <!{else}-->
   <script src="jquery.js"></script>
 <!--{endif}-->


### PR DESCRIPTION
This is needed to display icon buttons (and other functionality) in browsers that block mixed content.

Fixes https://github.com/webcompat/web-bugs/issues/498