### PR TITLE
Update README.md to link to the svgedit binaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-![alt text](https://progers.github.io/svgedit/images/logo48x48.svg "svg-edit logo of a pencil") SVG-edit 
+![alt text](https://svg-edit.github.io/svgedit/images/logo48x48.svg "svg-edit logo of a pencil") SVG-edit 
 ===
 SVG-edit is a fast, web-based, javascript-driven SVG drawing editor that works in any modern browser.
 
-### [Try SVG-edit here](http://progers.github.io/svgedit/releases/svg-edit-2.8/svg-editor.html)
+### [Try SVG-edit here](http://svg-edit.github.io/svgedit/releases/svg-edit-2.8/svg-editor.html)
 
-(Also available as a [download](https://github.com/progers/svgedit/releases/download/Releasev2.8/svg-edit-2.8.zip)).
+(Also available as a [download](https://github.com/SVG-Edit/svgedit/releases/download/svg-edit-2.8/svg-edit-2.8.zip) in [releases](https://github.com/SVG-Edit/svgedit/releases)).
 
 ## Recent news
   * 2015-11-24 SVG-edit 2.8 was released.


### PR DESCRIPTION
README.md previously pointed to binaries on progers's fork. Now that https://github.com/SVG-Edit/svgedit/pull/23 has landed we can update these links to point to the main repository.