### PR TITLE
Fix icons in Safari due to a redefinition of the xmlns attribute

### DIFF
--- a/editor/svgicons/jquery.svgicons.js
+++ b/editor/svgicons/jquery.svgicons.js
@@ -290,7 +290,9 @@ $(function() {
 					holder = $('#' + id);
 					var svg = elem.getElementsByTagNameNS(svgns, 'svg')[0];
 					var svgroot = document.createElementNS(svgns, "svg");
-					svgroot.setAttributeNS(svgns, 'viewBox', [0,0,icon_w,icon_h].join(' '));
+					// Per http://www.w3.org/TR/xml-names11/#defaulting, the namespace for
+					// attributes should have no value.
+					svgroot.setAttributeNS(null, 'viewBox', [0,0,icon_w,icon_h].join(' '));
 					
 					// Make flexible by converting width/height to viewBox
 					var w = svg.getAttribute('width');
@@ -317,9 +319,6 @@ $(function() {
 					svgroot.appendChild(svg);
 					var icon;
 					if(toImage) {
-						// Without cloning, Safari will crash
-						// With cloning, causes issue in Opera/Win/Non-EN
-						var svgcontent = isOpera?svgroot:svgroot.cloneNode(true);
 						temp_holder.empty().append(svgroot);
 						var str = data_pre + encode64(unescape(encodeURIComponent(new XMLSerializer().serializeToString(svgroot))));
 						icon = $(new Image())


### PR DESCRIPTION
https://github.com/SVG-Edit/svgedit/commit/b1f88d2b947f177688b1725326e7849280ea9a0b switched to using XMLSerializer which will create two xmlns attributes if a viewbox attribute is added with a non-null namespace. Two xmlns attributes results in a parse error in Safari which breaks all icons.

This change simply switches the viewBox setAttributeNS call to use a null namespace, per the xml-names11 recommendation. Without a rewrite, unit testing this change in jquery-svgicons is not really possible so I've just added a comment about why a null namespace is used. I've tested this change manually on firefox, safari, and chrome.

This change also removes the deadcode svgcontent variable that https://github.com/SVG-Edit/svgedit/commit/b1f88d2b947f177688b1725326e7849280ea9a0b left around.

This pull request fixes https://github.com/SVG-Edit/svgedit/issues/29