### PR TITLE
Switch imagelib to https urls, update project to be hosted over https

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ===
 SVG-edit is a fast, web-based, javascript-driven SVG drawing editor that works in any modern browser.
 
-### [Try SVG-edit here](http://svg-edit.github.io/svgedit/releases/svg-edit-2.8/svg-editor.html)
+### [Try SVG-edit here](https://svg-edit.github.io/svgedit/releases/svg-edit-2.8/svg-editor.html)
 
 (Also available as a [download](https://github.com/SVG-Edit/svgedit/releases/download/svg-edit-2.8/svg-edit-2.8.zip) in [releases](https://github.com/SVG-Edit/svgedit/releases)).
 

--- a/editor/extensions/ext-imagelib.js
+++ b/editor/extensions/ext-imagelib.js
@@ -30,12 +30,12 @@ svgEditor.addExtension("imagelib", function() {'use strict';
 		},
 		{
 			name: 'IAN Symbol Libraries',
-			url: 'http://ian.umces.edu/symbols/catalog/svgedit/album_chooser.php',
+			url: 'https://ian.umces.edu/symbols/catalog/svgedit/album_chooser.php',
 			description: 'Free library of illustrations'
 		},
 		{
 			name: 'Openclipart',
-			url: 'http://openclipart.org/svgedit',
+			url: 'https://openclipart.org/svgedit',
 			description: 'Share and Use Images. Over 50,000 Public Domain SVG Images and Growing.'
 		}
 	];


### PR DESCRIPTION
This pull request fixes issue https://github.com/SVG-Edit/svgedit/issues/31 so that svgedit can be served securely. There are side-channel attacks when using protocol relative urls (http://www.paulirish.com/2010/the-protocol-relative-url/) so this patch goes whole-hog on https.