### PR TITLE
Remove fix that cloned path segments and add tests to show it works

### DIFF
--- a/editor/path.js
+++ b/editor/path.js
@@ -478,16 +478,12 @@ svgedit.path.Segment.prototype.update = function(full) {
 svgedit.path.Segment.prototype.move = function(dx, dy) {
 	var cur_pts, item = this.item;
 
-	// fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
-	var cloneItem = $.extend({}, item);
-
-        if (this.ctrlpts) {
-                cur_pts = [cloneItem.x += dx, cloneItem.y += dy,
-                        cloneItem.x1, cloneItem.y1, cloneItem.x2 += dx, cloneItem.y2 += dy];
-        } else {
-                cur_pts = [cloneItem.x += dx, cloneItem.y += dy];
-        }
-	//fix
+	if (this.ctrlpts) {
+		cur_pts = [item.x += dx, item.y += dy,
+			item.x1, item.y1, item.x2 += dx, item.y2 += dy];
+	} else {
+		cur_pts = [item.x += dx, item.y += dy];
+	}
 
 	svgedit.path.replacePathSeg(this.type, this.index, cur_pts);
 
@@ -526,16 +522,12 @@ svgedit.path.Segment.prototype.setLinked = function(num) {
 	}
 
 	var item = seg.item;
-	// fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
-	var cloneItem = $.extend({}, item);
-        cloneItem['x' + anum ] = pt.x + (pt.x - this.item['x' + num]);
-        cloneItem['y' + anum ] = pt.y + (pt.y - this.item['y' + num]);
+	item['x' + anum ] = pt.x + (pt.x - this.item['x' + num]);
+	item['y' + anum ] = pt.y + (pt.y - this.item['y' + num]);
 
-        var pts = [cloneItem.x, cloneItem.y,
-              cloneItem.x1, cloneItem.y1,
-              cloneItem.x2, cloneItem.y2];
-        //end fix
-
+	var pts = [item.x, item.y,
+		item.x1, item.y1,
+		item.x2, item.y2];
 
 	svgedit.path.replacePathSeg(seg.type, seg.index, pts);
 	seg.update(true);
@@ -543,16 +535,11 @@ svgedit.path.Segment.prototype.setLinked = function(num) {
 
 svgedit.path.Segment.prototype.moveCtrl = function(num, dx, dy) {
 	var item = this.item;
+	item['x' + num] += dx;
+	item['y' + num] += dy;
 
-        // fix for path tool dom breakage, amending item does bad things now, so we take a copy and use that. Can probably improve to just take a shallow copy of object
-	var cloneItem = $.extend({}, item);
-        cloneItem['x' + num] += dx;
-        cloneItem['y' + num] += dy;
-
-        var pts = [cloneItem.x,cloneItem.y,
-                cloneItem.x1,cloneItem.y1, cloneItem.x2,cloneItem.y2];
-        // end fix
-
+	var pts = [item.x,item.y,
+		item.x1,item.y1, item.x2,item.y2];
 
 	svgedit.path.replacePathSeg(this.type, this.index, pts);
 	this.update(true);

--- a/test/path_test.html
+++ b/test/path_test.html
@@ -6,6 +6,9 @@
   <link rel='stylesheet' href='qunit/qunit.css' type='text/css'/>
   <script src='../editor/jquery.js'></script>
   <script src='../editor/svgedit.js'></script>
+  <script src='../editor/pathseg.js'></script>
+  <script src='../editor/browser.js'></script>
+  <script src='../editor/svgutils.js'></script>
   <script src='../editor/path.js'></script>
   <script src='qunit/qunit.js'></script>
   <script>
@@ -16,6 +19,135 @@
         window.console.log(details.result +' :: '+ details.message);
       }
     };
+
+    test('Test svgedit.path.replacePathSeg', function() {
+      expect(6);
+
+      var path = document.createElementNS(svgedit.NS.SVG, 'path');
+      path.setAttribute('d', 'M0,0 L10,11 L20,21Z');
+      svgedit.path.init();
+      svgedit.path.Path(path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'L');
+      equals(path.pathSegList.getItem(1).x, 10);
+      equals(path.pathSegList.getItem(1).y, 11);
+
+      svgedit.path.replacePathSeg(SVGPathSeg.PATHSEG_LINETO_REL, 1, [30, 31], path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'l');
+      equals(path.pathSegList.getItem(1).x, 30);
+      equals(path.pathSegList.getItem(1).y, 31);
+    });
+
+    test('Test svgedit.path.Segment.setType simple', function() {
+      expect(9);
+
+      var path = document.createElementNS(svgedit.NS.SVG, 'path');
+      path.setAttribute('d', 'M0,0 L10,11 L20,21Z');
+      svgedit.path.init();
+      svgedit.path.Path(path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'L');
+      equals(path.pathSegList.getItem(1).x, 10);
+      equals(path.pathSegList.getItem(1).y, 11);
+
+      var segment = new svgedit.path.Segment(1, path.pathSegList.getItem(1));
+      segment.setType(SVGPathSeg.PATHSEG_LINETO_REL, [30, 31]);
+      equals(segment.item.pathSegTypeAsLetter, 'l');
+      equals(segment.item.x, 30);
+      equals(segment.item.y, 31);
+
+      // Also verify that the actual path changed.
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'l');
+      equals(path.pathSegList.getItem(1).x, 30);
+      equals(path.pathSegList.getItem(1).y, 31);
+    });
+
+    test('Test svgedit.path.Segment.setType with control points', function() {
+      expect(14);
+
+      // Setup the dom for a mock control group.
+      var svg = document.createElementNS(svgedit.NS.SVG, 'svg');
+      var path = document.createElementNS(svgedit.NS.SVG, 'path');
+      path.setAttribute('d', 'M0,0 C11,12 13,14 15,16 Z');
+      svg.appendChild(path);
+      var selectorParentGroup = document.createElementNS(svgedit.NS.SVG, 'g');
+      selectorParentGroup.setAttribute('id', 'selectorParentGroup');
+      svg.appendChild(selectorParentGroup);
+      var mockContext = {
+        getDOMDocument: function() { return svg; },
+        getDOMContainer: function() { return svg; },
+        getSVGRoot: function() { return svg; },
+        getCurrentZoom: function() { return 1; }
+      };
+      svgedit.path.init(mockContext);
+      svgedit.utilities.init(mockContext);
+      var segment = new svgedit.path.Segment(1, path.pathSegList.getItem(1));
+      segment.path = new svgedit.path.Path(path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'C');
+      equals(path.pathSegList.getItem(1).x1, 11);
+      equals(path.pathSegList.getItem(1).y1, 12);
+      equals(path.pathSegList.getItem(1).x2, 13);
+      equals(path.pathSegList.getItem(1).y2, 14);
+      equals(path.pathSegList.getItem(1).x, 15);
+      equals(path.pathSegList.getItem(1).y, 16);
+
+      segment.setType(SVGPathSeg.PATHSEG_CURVETO_CUBIC_REL, [30, 31, 32, 33, 34, 35]);
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'c');
+      equals(path.pathSegList.getItem(1).x1, 32);
+      equals(path.pathSegList.getItem(1).y1, 33);
+      equals(path.pathSegList.getItem(1).x2, 34);
+      equals(path.pathSegList.getItem(1).y2, 35);
+      equals(path.pathSegList.getItem(1).x, 30);
+      equals(path.pathSegList.getItem(1).y, 31);
+    });
+
+    test('Test svgedit.path.Segment.move', function() {
+      expect(6);
+
+      var path = document.createElementNS(svgedit.NS.SVG, 'path');
+      path.setAttribute('d', 'M0,0 L10,11 L20,21Z');
+      svgedit.path.init();
+      svgedit.path.Path(path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'L');
+      equals(path.pathSegList.getItem(1).x, 10);
+      equals(path.pathSegList.getItem(1).y, 11);
+
+      var segment = new svgedit.path.Segment(1, path.pathSegList.getItem(1));
+      segment.move(-3, 4);
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'L');
+      equals(path.pathSegList.getItem(1).x, 7);
+      equals(path.pathSegList.getItem(1).y, 15);
+    });
+
+    test('Test svgedit.path.Segment.moveCtrl', function() {
+      expect(14);
+
+      var path = document.createElementNS(svgedit.NS.SVG, 'path');
+      path.setAttribute('d', 'M0,0 C11,12 13,14 15,16 Z');
+      svgedit.path.init();
+      svgedit.path.Path(path);
+
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'C');
+      equals(path.pathSegList.getItem(1).x1, 11);
+      equals(path.pathSegList.getItem(1).y1, 12);
+      equals(path.pathSegList.getItem(1).x2, 13);
+      equals(path.pathSegList.getItem(1).y2, 14);
+      equals(path.pathSegList.getItem(1).x, 15);
+      equals(path.pathSegList.getItem(1).y, 16);
+
+      var segment = new svgedit.path.Segment(1, path.pathSegList.getItem(1));
+      segment.moveCtrl(1, 100, -200);
+      equals(path.pathSegList.getItem(1).pathSegTypeAsLetter, 'C');
+      equals(path.pathSegList.getItem(1).x1, 111);
+      equals(path.pathSegList.getItem(1).y1, -188);
+      equals(path.pathSegList.getItem(1).x2, 13);
+      equals(path.pathSegList.getItem(1).y2, 14);
+      equals(path.pathSegList.getItem(1).x, 15);
+      equals(path.pathSegList.getItem(1).y, 16);
+    });
   });
   </script>
 </head>


### PR DESCRIPTION
This largely reverts fbbd740c794e27a384eea0abd7987a1515b0a6b4 and adds tests (passing in firefox, chrome, and safari) to show svgedit still works. I also manually tested the path tool in each browser and didn't notice any bugs.

I am not sure which bug fbbd740c794e27a384eea0abd7987a1515b0a6b4 was fixing but if it crops up again we now have the test infrastructure to better test it.

This fixes #66.