### PR TITLE
Images drawn using an extension always spawn the URL dialog

### DIFF
--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -1563,7 +1563,7 @@ TODOS
 					$('#blur_slider').slider('option', 'value', blurval);
 
 					if (svgCanvas.addedNew) {
-						if (elname === 'image') {
+						if (elname === 'image' && svgCanvas.getMode() === 'image') {
 							// Prompt for URL if not a data URL
 							if (svgCanvas.getHref(elem).indexOf('data:') !== 0) {
 								promptImgURL();
@@ -1708,7 +1708,8 @@ TODOS
 								}, 100);
 							}
 						} // text
-						else if (el_name == 'image') {
+						else if (el_name == 'image' && svgCanvas.getMode() == 'image') {
+							debugger;
 							setImageURL(svgCanvas.getHref(elem));
 						} // image
 						else if (el_name === 'g' || el_name === 'use') {

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -1709,7 +1709,6 @@ TODOS
 							}
 						} // text
 						else if (el_name == 'image' && svgCanvas.getMode() == 'image') {
-							debugger;
 							setImageURL(svgCanvas.getHref(elem));
 						} // image
 						else if (el_name === 'g' || el_name === 'use') {


### PR DESCRIPTION
I made a change here to the editor to only show the select image URL dialog for an image if the canvas mode is "image".

This way we can add an image as part of an extension without forcing the default behavior.