### PR TITLE
Expose current zoom level through canvas for extensions 

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -5505,6 +5505,11 @@ var getResolution = this.getResolution = function() {
 // Returns the current zoom level
 this.getZoom = function(){return current_zoom;};
 
+// Function: getSnapToGrid
+// Returns the current snap to grid setting
+this.getSnapToGrid = function(){return curConfig.gridSnapping;};
+
+
 // Function: getVersion
 // Returns a string which describes the revision number of SvgCanvas.
 this.getVersion = function() {


### PR DESCRIPTION
As the canvas exposes the current zoom level it seemed appropriate to add the gridSnapping setting here as an access function for extensions to make use of as well.