### PR TITLE
Corrected case of jquery.contextMenu.js in make file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ZIP=zip
 JS_FILES=\
 	svgedit.js \
 	jquery-svg.js \
-	contextmenu/jquery.contextmenu.js \
+	contextmenu/jquery.contextMenu.js \
 	pathseg.js \
 	browser.js \
 	svgtransformlist.js \


### PR DESCRIPTION
Builds fail because they can't read jquery.contextMenu.js without this change.