### PR TITLE
Update layers panel on programatic call to createLayer.

### DIFF
--- a/editor/draw.js
+++ b/editor/draw.js
@@ -414,7 +414,7 @@ svgedit.draw.Drawing.prototype.getLayerName = function (i) {
  * @returns {SVGGElement} The SVGGElement representing the current layer.
  */
 svgedit.draw.Drawing.prototype.getCurrentLayer = function() {
-	return this.current_layer.getGroup();
+	return this.current_layer ? this.current_layer.getGroup() : null;
 };
 
 /**

--- a/editor/draw.js
+++ b/editor/draw.js
@@ -232,7 +232,8 @@ svgedit.draw.Drawing = function(svgElem, opt_idPrefix) {
 	this.releasedNums = [];
 
 	/**
-	 * The z-ordered array of tuples containing layer names and <g> elements.
+	 * The z-ordered array of Layer objects. Each layer has a name
+	 * and group element.
 	 * The first layer is the one at the bottom of the rendering.
 	 * @type {Layer[]}
 	 */

--- a/editor/draw.js
+++ b/editor/draw.js
@@ -113,10 +113,10 @@ Layer.prototype.deactivate = function() {
  * Set this layer visible or hidden based on 'visible' parameter.
  * @param {boolean} visible - If true, make visible; otherwise, hide it.
  */
-Layer.prototype.setVisible = function( visible) {
+Layer.prototype.setVisible = function(visible) {
 	var expected = visible === undefined || visible ? "inline" : "none";
 	var oldDisplay = this.group_.getAttribute("display");
-	if( oldDisplay !== expected) {
+	if (oldDisplay !== expected) {
 		this.group_.setAttribute("display", expected);
 	}
 };
@@ -135,7 +135,7 @@ Layer.prototype.isVisible = function() {
  */
 Layer.prototype.getOpacity = function() {
 	var opacity = this.group_.getAttribute('opacity');
-	if( opacity === null || opacity === undefined) {
+	if (opacity === null || opacity === undefined) {
 		return 1;
 	}
 	return parseFloat(opacity);
@@ -146,7 +146,7 @@ Layer.prototype.getOpacity = function() {
  * nothing happens.
  * @param {number} opacity - A float value in the range 0.0-1.0
  */
-Layer.prototype.setOpacity = function( opacity) {
+Layer.prototype.setOpacity = function(opacity) {
 	if (typeof opacity === 'number' && opacity >= 0.0 && opacity <= 1.0) {
 		this.group_.setAttribute('opacity', opacity);
 	}
@@ -156,7 +156,7 @@ Layer.prototype.setOpacity = function( opacity) {
  * Append children to this layer.
  * @param {SVGGElement} children - The children to append to this layer.
  */
-Layer.prototype.appendChildren = function( children) {
+Layer.prototype.appendChildren = function(children) {
 	for (var i = 0; i < children.length; ++i) {
 		this.group_.appendChild(children[i]);
 	}
@@ -470,7 +470,7 @@ function findLayerNameInGroup(group) {
 	var name = $("title", group).text();
 
 	// Hack for Opera 10.60
-	if(!name && svgedit.browser.isOpera() && group.querySelectorAll) {
+	if (!name && svgedit.browser.isOpera() && group.querySelectorAll) {
 		name = $(group.querySelectorAll('title')).text();
 	}
 	return name;
@@ -481,7 +481,7 @@ function findLayerNameInGroup(group) {
  * @param {string[]} existingLayerNames - Existing layer names.
  * @returns {string} - The new name.
  */
-function getNewLayerName( existingLayerNames) {
+function getNewLayerName(existingLayerNames) {
 	var i = 1;
 	// TODO(codedread): What about internationalization of "Layer"?
 	while (existingLayerNames.indexOf(("Layer " + i)) >= 0) { i++; }
@@ -509,14 +509,14 @@ svgedit.draw.Drawing.prototype.identifyLayers = function() {
 				var name = findLayerNameInGroup(child);
 				if (name) {
 					layernames.push(name);
-					layer = new Layer( name, child);
+					layer = new Layer(name, child);
 					this.all_layers.push(layer);
 					this.layer_map[ name] = layer;
 				} else {
 					// if group did not have a name, it is an orphan
 					orphans.push(child);
 				}
-			} else if(~visElems.indexOf(child.nodeName)) {
+			} else if (~visElems.indexOf(child.nodeName)) {
 				// Child is "visible" (i.e. not a <title> or <defs> element), so it is an orphan
 				orphans.push(child);
 			}
@@ -525,7 +525,7 @@ svgedit.draw.Drawing.prototype.identifyLayers = function() {
 	
 	// If orphans or no layers found, create a new layer and add all the orphans to it
 	if (orphans.length > 0 || !childgroups) {
-		layer = new Layer( getNewLayerName(layernames), null, this.svgElem_);
+		layer = new Layer(getNewLayerName(layernames), null, this.svgElem_);
 		layer.appendChildren(orphans);
 		this.all_layers.push(layer);
 		this.layer_map[ name] = layer;
@@ -543,14 +543,14 @@ svgedit.draw.Drawing.prototype.identifyLayers = function() {
  * also the current layer of this drawing.
 */
 svgedit.draw.Drawing.prototype.createLayer = function(name) {
-	if( this.current_layer) {
+	if (this.current_layer) {
 		this.current_layer.deactivate();
 	}
 	// Check for duplicate name.
-	if( name === undefined || name === null || name === '' || this.layer_map[name]) {
+	if (name === undefined || name === null || name === '' || this.layer_map[name]) {
 		name = getNewLayerName(Object.keys(this.layer_map));
 	}
-	var layer = new Layer( name, null, this.svgElem_);
+	var layer = new Layer(name, null, this.svgElem_);
 	this.all_layers.push(layer);
 	this.layer_map[ name] = layer;
 	this.current_layer = layer;

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -1835,6 +1835,15 @@ TODOS
 				});
 			};
 
+			/**
+			 * Test whether an element is a layer or not.
+			 * @param {SVGGElement} elem - The SVGGElement to test.
+			 * @returns {boolean} True if the element is a layer
+			 */
+			function isLayer(elem) {
+				return elem && elem.tagName === 'g' && svgedit.LAYER_CLASS_REGEX.test(elem.getAttribute('class'))
+			}
+
 			// called when any element has changed
 			var elementChanged = function(win, elems) {
 				var i,
@@ -1846,10 +1855,13 @@ TODOS
 				for (i = 0; i < elems.length; ++i) {
 					var elem = elems[i];
 
-					// if the element changed was the svg, then it could be a resolution change
-					if (elem && elem.tagName === 'svg') {
+					var isSvgElem = (elem && elem.tagName === 'svg');
+					if (isSvgElem || isLayer(elem)) {
 						populateLayers();
-						updateCanvas();
+						// if the element changed was the svg, then it could be a resolution change
+						if (isSvgElem) {
+							updateCanvas();
+						}
 					}
 					// Update selectedElement if element is no longer part of the image.
 					// This occurs for the text elements in Firefox

--- a/editor/svgedit.js
+++ b/editor/svgedit.js
@@ -15,8 +15,10 @@ svgedit = {
 		XLINK: 'http://www.w3.org/1999/xlink',
 		XML: 'http://www.w3.org/XML/1998/namespace',
 		XMLNS: 'http://www.w3.org/2000/xmlns/' // see http://www.w3.org/TR/REC-xml-names/#xmlReserved
-	}
+	},
+	LAYER_CLASS: 'layer'
 };
+svgedit.LAYER_CLASS_REGEX = new RegExp('(\\s|^)' + svgedit.LAYER_CLASS + '(\\s|$)');
 
 // return the svgedit.NS with key values switched and lowercase
 svgedit.getReverseNS = function() {'use strict';

--- a/test/draw_test.html
+++ b/test/draw_test.html
@@ -258,16 +258,17 @@
       ok(drawing.getSvgElem().hasChildNodes());
       equals(drawing.getSvgElem().childNodes.length, 1);
 
-      // Check that all_layers is correctly set up.
+      // Check that all_layers are correctly set up.
       equals(drawing.getNumLayers(), 1);
-      var empty_layer = drawing.all_layers[0][1];
+      var empty_layer = drawing.all_layers[0];
       ok(empty_layer);
-      equals(empty_layer, drawing.getSvgElem().firstChild);
-      equals(empty_layer.tagName, 'g');
-      equals(empty_layer.getAttribute('class'), LAYER_CLASS);
-      ok(empty_layer.hasChildNodes());
-      equals(empty_layer.childNodes.length, 1);
-      var firstChild = empty_layer.childNodes.item(0);
+      var layerGroup = empty_layer.getGroup();
+      equals(layerGroup, drawing.getSvgElem().firstChild);
+      equals(layerGroup.tagName, 'g');
+      equals(layerGroup.getAttribute('class'), LAYER_CLASS);
+      ok(layerGroup.hasChildNodes());
+      equals(layerGroup.childNodes.length, 1);
+      var firstChild = layerGroup.childNodes.item(0);
       equals(firstChild.tagName, 'title');
 
       cleanupSvg(svg);
@@ -284,13 +285,13 @@
       drawing.identifyLayers();
 
       equals(drawing.getNumLayers(), 3);
-      equals(drawing.all_layers[0][1], svg.childNodes.item(0));
-      equals(drawing.all_layers[1][1], svg.childNodes.item(1));
-      equals(drawing.all_layers[2][1], svg.childNodes.item(2));
+      equals(drawing.all_layers[0].getGroup(), svg.childNodes.item(0));
+      equals(drawing.all_layers[1].getGroup(), svg.childNodes.item(1));
+      equals(drawing.all_layers[2].getGroup(), svg.childNodes.item(2));
 
-      equals(drawing.all_layers[0][1].getAttribute('class'), LAYER_CLASS);
-      equals(drawing.all_layers[1][1].getAttribute('class'), LAYER_CLASS);
-      equals(drawing.all_layers[2][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[0].getGroup().getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[1].getGroup().getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[2].getGroup().getAttribute('class'), LAYER_CLASS);
 
       cleanupSvg(svg);
     });
@@ -311,17 +312,17 @@
       drawing.identifyLayers();
 
       equals(drawing.getNumLayers(), 4);
-      equals(drawing.all_layers[0][1], svg.childNodes.item(0));
-      equals(drawing.all_layers[1][1], svg.childNodes.item(1));
-      equals(drawing.all_layers[2][1], svg.childNodes.item(2));
-      equals(drawing.all_layers[3][1], svg.childNodes.item(3));
+      equals(drawing.all_layers[0].getGroup(), svg.childNodes.item(0));
+      equals(drawing.all_layers[1].getGroup(), svg.childNodes.item(1));
+      equals(drawing.all_layers[2].getGroup(), svg.childNodes.item(2));
+      equals(drawing.all_layers[3].getGroup(), svg.childNodes.item(3));
 
-      equals(drawing.all_layers[0][1].getAttribute('class'), LAYER_CLASS);
-      equals(drawing.all_layers[1][1].getAttribute('class'), LAYER_CLASS);
-      equals(drawing.all_layers[2][1].getAttribute('class'), LAYER_CLASS);
-      equals(drawing.all_layers[3][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[0].getGroup().getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[1].getGroup().getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[2].getGroup().getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[3].getGroup().getAttribute('class'), LAYER_CLASS);
 
-      var layer4 = drawing.all_layers[3][1];
+      var layer4 = drawing.all_layers[3].getGroup();
       equals(layer4.tagName, 'g');
       equals(layer4.childNodes.length, 3);
       equals(layer4.childNodes.item(1), orphan1);
@@ -356,7 +357,9 @@
       ok(drawing.getCurrentLayer);
       equals(typeof drawing.getCurrentLayer, typeof function(){});
       ok(drawing.getCurrentLayer());
-      equals(drawing.getCurrentLayer(), drawing.all_layers[2][1]);
+      equals(drawing.getCurrentLayer(), drawing.all_layers[2].getGroup());
+
+      cleanupSvg(svg);
     });
 
     test('Test setCurrentLayer() and getCurrentLayerName()', function() {
@@ -371,11 +374,11 @@
 
       drawing.setCurrentLayer(LAYER2);
       equals(drawing.getCurrentLayerName(LAYER2), LAYER2);
-      equals(drawing.getCurrentLayer(), drawing.all_layers[1][1]);
+      equals(drawing.getCurrentLayer(), drawing.all_layers[1].getGroup());
 
       drawing.setCurrentLayer(LAYER3);
       equals(drawing.getCurrentLayerName(LAYER3), LAYER3);
-      equals(drawing.getCurrentLayer(), drawing.all_layers[2][1]);
+      equals(drawing.getCurrentLayer(), drawing.all_layers[2].getGroup());
 
       cleanupSvg(svg);
     });
@@ -392,7 +395,7 @@
 
       var NEW_LAYER_NAME = 'Layer A';
       var layer_g = drawing.createLayer(NEW_LAYER_NAME);
-      equals(4, drawing.getNumLayers());
+      equals(drawing.getNumLayers(), 4);
       equals(layer_g, drawing.getCurrentLayer());
       equals(layer_g.getAttribute('class'), LAYER_CLASS);
       equals(NEW_LAYER_NAME, drawing.getCurrentLayerName());
@@ -492,14 +495,14 @@
       drawing.setCurrentLayer(LAYER2);
 
       var curLayer = drawing.getCurrentLayer();
-      equals(curLayer, drawing.all_layers[1][1]);
+      equals(curLayer, drawing.all_layers[1].getGroup());
       var deletedLayer = drawing.deleteCurrentLayer();
 
       equals(curLayer, deletedLayer);
       equals(2, drawing.getNumLayers());
-      equals(LAYER1, drawing.all_layers[0][0]);
-      equals(LAYER3, drawing.all_layers[1][0]);
-      equals(drawing.getCurrentLayer(), drawing.all_layers[1][1]);
+      equals(LAYER1, drawing.all_layers[0].getName());
+      equals(LAYER3, drawing.all_layers[1].getName());
+      equals(drawing.getCurrentLayer(), drawing.all_layers[1].getGroup());
     });
 
     test('Test svgedit.draw.randomizeIds()', function() {

--- a/test/draw_test.html
+++ b/test/draw_test.html
@@ -248,9 +248,10 @@
     });
 
     test('Test identifyLayers() with empty document', function() {
-      expect(10);
+      expect(11);
 
       var drawing = new svgedit.draw.Drawing(svg);
+      equals(drawing.getCurrentLayer(), null);
       // By default, an empty document gets an empty group created.
       drawing.identifyLayers();
 

--- a/test/draw_test.html
+++ b/test/draw_test.html
@@ -19,12 +19,16 @@
       }
     };
     var NS = svgedit.NS;
+    var LAYER_CLASS = svgedit.LAYER_CLASS;
     var NONCE = 'foo';
     var LAYER1 = 'Layer 1';
     var LAYER2 = 'Layer 2';
     var LAYER3 = 'Layer 3';
 
     var svg = document.createElementNS(NS.SVG, 'svg');
+    var sandbox = document.getElementById('sandbox');
+    // Firefox throws exception in getBBox() when svg is not attached to DOM.
+    sandbox.appendChild(svg);
 
     // Set up <svg> with nonce.
     var svg_n = document.createElementNS(NS.SVG, 'svg');
@@ -244,7 +248,7 @@
     });
 
     test('Test identifyLayers() with empty document', function() {
-      expect(9);
+      expect(10);
 
       var drawing = new svgedit.draw.Drawing(svg);
       // By default, an empty document gets an empty group created.
@@ -260,6 +264,7 @@
       ok(empty_layer);
       equals(empty_layer, drawing.getSvgElem().firstChild);
       equals(empty_layer.tagName, 'g');
+      equals(empty_layer.getAttribute('class'), LAYER_CLASS);
       ok(empty_layer.hasChildNodes());
       equals(empty_layer.childNodes.length, 1);
       var firstChild = empty_layer.childNodes.item(0);
@@ -269,7 +274,7 @@
     });
 
     test('Test identifyLayers() with some layers', function() {
-      expect(5);
+      expect(8);
 
       var drawing = new svgedit.draw.Drawing(svg);
       setupSvgWith3Layers(svg);
@@ -283,11 +288,15 @@
       equals(drawing.all_layers[1][1], svg.childNodes.item(1));
       equals(drawing.all_layers[2][1], svg.childNodes.item(2));
 
+      equals(drawing.all_layers[0][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[1][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[2][1].getAttribute('class'), LAYER_CLASS);
+
       cleanupSvg(svg);
     });
 
     test('Test identifyLayers() with some layers and orphans', function() {
-      expect(10);
+      expect(14);
 
       setupSvgWith3Layers(svg);
 
@@ -306,6 +315,11 @@
       equals(drawing.all_layers[1][1], svg.childNodes.item(1));
       equals(drawing.all_layers[2][1], svg.childNodes.item(2));
       equals(drawing.all_layers[3][1], svg.childNodes.item(3));
+
+      equals(drawing.all_layers[0][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[1][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[2][1].getAttribute('class'), LAYER_CLASS);
+      equals(drawing.all_layers[3][1].getAttribute('class'), LAYER_CLASS);
 
       var layer4 = drawing.all_layers[3][1];
       equals(layer4.tagName, 'g');
@@ -367,7 +381,7 @@
     });
 
     test('Test createLayer()', function() {
-      expect(6);
+      expect(7);
 
       var drawing = new svgedit.draw.Drawing(svg);
       setupSvgWith3Layers(svg);
@@ -380,6 +394,7 @@
       var layer_g = drawing.createLayer(NEW_LAYER_NAME);
       equals(4, drawing.getNumLayers());
       equals(layer_g, drawing.getCurrentLayer());
+      equals(layer_g.getAttribute('class'), LAYER_CLASS);
       equals(NEW_LAYER_NAME, drawing.getCurrentLayerName());
       equals(NEW_LAYER_NAME, drawing.getLayerName(3));
 
@@ -530,6 +545,6 @@
   <h2 id='qunit-banner'></h2>
   <h2 id='qunit-userAgent'></h2>
   <ol id='qunit-tests'></ol>
-  <div id='anchor' style='visibility:hidden'></div>
+  <div id='sandbox' style='visibility:hidden'></div>
 </body>
 </html>


### PR DESCRIPTION
This is intended to fix [issue 104](https://github.com/SVG-Edit/svgedit/issues/104). It adds class=“layer” to each layer element, so calling createLayer programmatically is easily detected in elementChanged and the layers panel is always updated appropriately. It's backwards compatible with legacy drawings because it auto-adds the class to legacy drawings.

**Note:** [coderead](https://github.com/codedread) seemed to prefer this solution, but wasn't committed. I decided to try it out and see how it went. I think it worked out well; so I decided to do a pull request. See commit notes below.

### Problem
For our application; on startup of svgedit, we rename "Layer 1" and create a second layer. The layers panel is not repopulated and still shows one layer, "Layer 1" even though the document has been updated correctly.

### Analysis
createLayer does issue `call('changed', [new_layer])`, but the layers panel is looking for change to `svg#svgcontent`, not the `<g>` element of the new layer.

Here's the relevant code in svg-editor.js
```
var elementChanged = function(win, elems) {
  ...
  if (elem && elem.tagName === 'svg') {
    populateLayers();
    updateCanvas();
  }
  ...
}
```

### Commit Notes
Add class=“layer” to each layer element. This happens when calling createLayer() or any call to identifyLayers(). This happens with new drawings and when opening legacy drawings, so it’s fully backwards compatible.

svg-editor.js elementChanged() looks for g.layer as an addition test when calling populateLayers(). This updates the layers panel.

Added tests for class=“layer” added to draw_test.html.

Fixed Firefox exception in draw_test.html. It was failing in native getBBox() because, in the test, the SVG element was not attached to the DOM.