### PR TITLE
Fixed Layers in svgcanvas. Moved Layer class. HistoryRecordingservice

### DIFF
--- a/editor/historyrecording.js
+++ b/editor/historyrecording.js
@@ -1,0 +1,173 @@
+/*globals svgedit*/
+/*jslint vars: true, eqeq: true */
+/**
+ * Package: svgedit.history
+ *
+ * Licensed under the MIT License
+ *
+ * Copyright(c) 2010 Alexis Deveria
+ * Copyright(c) 2010 Jeff Schiller
+ * Copyright(c) 2016 Flint O'Brien
+ */
+
+// Dependencies:
+// 1) history.js
+
+(function() {
+	'use strict';
+
+if (!svgedit.history) {
+	svgedit.history = {};
+}
+var history = svgedit.history;
+
+/**
+ * History recording service.
+ *
+ * A <strong>single</strong> service object that can be passed around to provide history
+ * recording. There is a simple start/end interface for batch commands.
+ * Easy to mock for unit tests. Built on top of history classes in history.js.
+ *
+ * HistoryRecordingService.NO_HISTORY is a singleton that can be passed in to functions
+ * that record history. This helps when the caller requires that no history be recorded.
+ *
+ * Usage:
+ * The following will record history: insert, batch, insert.
+ * ```
+ * hrService = new svgedit.history.HistoryRecordingService(this.undoMgr);
+ * hrService.insertElement(elem, text);         // add simple command to history.
+ * hrService.startBatchCommand('create two elements');
+ * hrService.changeElement(elem, attrs, text);  // add to batchCommand
+ * hrService.changeElement(elem, attrs2, text); // add to batchCommand
+ * hrService.endBatchCommand();                  // add batch command with two change commands to history.
+ * hrService.insertElement(elem, text);         // add simple command to history.
+ * ```
+ *
+ * Note that all functions return this, so commands can be chained, like so:
+ *
+ * ```
+ * hrService
+ *   .startBatchCommand('create two elements')
+ *   .insertElement(elem, text)
+ *   .changeElement(elem, attrs, text)
+ *   .endBatchCommand();
+ * ```
+ *
+ * @param {svgedit.history.UndoManager} undoManager - The undo manager.
+ * 		A value of null is valid for cases where no history recording is required.
+ * 		See singleton: HistoryRecordingService.NO_HISTORY
+ */
+var HistoryRecordingService = history.HistoryRecordingService = function(undoManager) {
+	this.undoManager = undoManager;
+	this.currentBatchCommand = null;
+	this.batchCommandStack = [];
+};
+
+/**
+ * @type {svgedit.history.HistoryRecordingService} NO_HISTORY - Singleton that can be passed
+ *		in to functions that record history, but the caller requires that no history be recorded.
+ */
+HistoryRecordingService.NO_HISTORY = new HistoryRecordingService();
+
+/**
+ * Start a batch command so multiple commands can recorded as a single history command.
+ * Requires a corresponding call to endBatchCommand. Start and end commands can be nested.
+ *
+ * @param {string} text - Optional string describing the batch command.
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.startBatchCommand = function(text) {
+	if (!this.undoManager) {return this;}
+	this.currentBatchCommand = new history.BatchCommand(text);
+	this.batchCommandStack.push(this.currentBatchCommand);
+	return this;
+};
+
+/**
+ * End a batch command and add it to the history or a parent batch command.
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.endBatchCommand = function() {
+	if (!this.undoManager) {return this;}
+	if (this.currentBatchCommand) {
+		var batchCommand = this.currentBatchCommand;
+		this.batchCommandStack.pop();
+		var length = this.batchCommandStack.length;
+		this.currentBatchCommand = length ? this.batchCommandStack[length-1] : null;
+		this._addCommand(batchCommand);
+	}
+	return this;
+};
+
+/**
+ * Add a MoveElementCommand to the history or current batch command
+ * @param {Element} elem - The DOM element that was moved
+ * @param {Element} oldNextSibling - The element's next sibling before it was moved
+ * @param {Element} oldParent - The element's parent before it was moved
+ * @param {string} [text] - An optional string visible to user related to this change
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.moveElement = function(elem, oldNextSibling, oldParent, text) {
+	if (!this.undoManager) {return this;}
+	this._addCommand(new history.MoveElementCommand(elem, oldNextSibling, oldParent, text));
+	return this;
+};
+
+/**
+ * Add an InsertElementCommand to the history or current batch command
+ * @param {Element} elem - The DOM element that was added
+ * @param {string} [text] - An optional string visible to user related to this change
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.insertElement = function(elem, text) {
+	if (!this.undoManager) {return this;}
+	this._addCommand(new history.InsertElementCommand(elem, text));
+	return this;
+};
+
+
+/**
+ * Add a RemoveElementCommand to the history or current batch command
+ * @param {Element} elem - The DOM element that was removed
+ * @param {Element} oldNextSibling - The element's next sibling before it was removed
+ * @param {Element} oldParent - The element's parent before it was removed
+ * @param {string} [text] - An optional string visible to user related to this change
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.removeElement = function(elem, oldNextSibling, oldParent, text) {
+	if (!this.undoManager) {return this;}
+	this._addCommand(new history.RemoveElementCommand(elem, oldNextSibling, oldParent, text));
+	return this;
+};
+
+
+/**
+ * Add a ChangeElementCommand to the history or current batch command
+ * @param {Element} elem - The DOM element that was changed
+ * @param {object} attrs - An object with the attributes to be changed and the values they had *before* the change
+ * @param {string} [text] - An optional string visible to user related to this change
+ * @returns {svgedit.history.HistoryRecordingService}
+ */
+HistoryRecordingService.prototype.changeElement = function(elem, attrs, text) {
+	if (!this.undoManager) {return this;}
+	this._addCommand(new history.ChangeElementCommand(elem, attrs, text));
+	return this;
+};
+
+/**
+ * Private function to add a command to the history or current batch command.
+ * @param cmd
+ * @returns {svgedit.history.HistoryRecordingService}
+ * @private
+ */
+HistoryRecordingService.prototype._addCommand = function(cmd) {
+	if (!this.undoManager) {return this;}
+	if (this.currentBatchCommand) {
+		this.currentBatchCommand.addSubCommand(cmd);
+	} else {
+		this.undoManager.addCommandToHistory(cmd);
+	}
+};
+
+
+}());

--- a/editor/layer.js
+++ b/editor/layer.js
@@ -1,0 +1,200 @@
+/*globals svgedit*/
+/*jslint vars: true, eqeq: true */
+/**
+ * Package: svgedit.history
+ *
+ * Licensed under the MIT License
+ *
+ * Copyright(c) 2011 Jeff Schiller
+ * Copyright(c) 2016 Flint O'Brien
+ */
+
+// Dependencies:
+// 1) svgedit.js
+// 2) draw.js
+
+(function() {
+	'use strict';
+
+if (!svgedit.draw) {
+  svgedit.draw = {};
+}
+var NS = svgedit.NS;
+
+
+/**
+ * This class encapsulates the concept of a layer in the drawing. It can be constructed with
+ * an existing group element or, with three parameters, will create a new layer group element.
+ * @param {string} name - Layer name
+ * @param {SVGGElement} group - SVG group element that constitutes the layer or null if a group should be created and added to the DOM..
+ * @param {SVGGElement} svgElem - The SVG DOM element. If defined, use this to add
+ * 		a new layer to the document.
+ */
+var Layer = svgedit.draw.Layer = function(name, group, svgElem) {
+  this.name_ = name;
+  this.group_ = group;
+
+  if (!group) {
+    // Create a group element with title and add it to the DOM.
+    var svgdoc = svgElem.ownerDocument;
+    this.group_ = svgdoc.createElementNS(NS.SVG, "g");
+    var layer_title = svgdoc.createElementNS(NS.SVG, "title");
+    layer_title.textContent = name;
+    this.group_.appendChild(layer_title);
+    svgElem.appendChild(this.group_);
+  }
+
+  addLayerClass(this.group_);
+  svgedit.utilities.walkTree(this.group_, function(e){e.setAttribute("style", "pointer-events:inherit");});
+
+  this.group_.setAttribute("style", svgElem ? "pointer-events:all" : "pointer-events:none");
+};
+
+/**
+ * @type {string} CLASS_NAME - class attribute assigned to all layer groups.
+ */
+Layer.CLASS_NAME = 'layer';
+
+/**
+ * @type {RegExp} CLASS_REGEX - Used to test presence of class Layer.CLASS_NAME
+ */
+Layer.CLASS_REGEX = new RegExp('(\\s|^)' + Layer.CLASS_NAME + '(\\s|$)');
+
+
+/**
+ * Get the layer's name.
+ * @returns {string} The layer name
+ */
+Layer.prototype.getName = function() {
+  return this.name_;
+};
+
+/**
+ * Get the group element for this layer.
+ * @returns {SVGGElement} The layer SVG group
+ */
+Layer.prototype.getGroup = function() {
+  return this.group_;
+};
+
+/**
+ * Active this layer so it takes pointer events.
+ */
+Layer.prototype.activate = function() {
+  this.group_.setAttribute("style", "pointer-events:all");
+};
+
+/**
+ * Deactive this layer so it does NOT take pointer events.
+ */
+Layer.prototype.deactivate = function() {
+  this.group_.setAttribute("style", "pointer-events:none");
+};
+
+/**
+ * Set this layer visible or hidden based on 'visible' parameter.
+ * @param {boolean} visible - If true, make visible; otherwise, hide it.
+ */
+Layer.prototype.setVisible = function(visible) {
+  var expected = visible === undefined || visible ? "inline" : "none";
+  var oldDisplay = this.group_.getAttribute("display");
+  if (oldDisplay !== expected) {
+    this.group_.setAttribute("display", expected);
+  }
+};
+
+/**
+ * Is this layer visible?
+ * @returns {boolean} True if visible.
+ */
+Layer.prototype.isVisible = function() {
+  return this.group_.getAttribute('display') !== 'none';
+};
+
+/**
+ * Get layer opacity.
+ * @returns {number} Opacity value.
+ */
+Layer.prototype.getOpacity = function() {
+  var opacity = this.group_.getAttribute('opacity');
+  if (opacity === null || opacity === undefined) {
+    return 1;
+  }
+  return parseFloat(opacity);
+};
+
+/**
+ * Sets the opacity of this layer. If opacity is not a value between 0.0 and 1.0,
+ * nothing happens.
+ * @param {number} opacity - A float value in the range 0.0-1.0
+ */
+Layer.prototype.setOpacity = function(opacity) {
+  if (typeof opacity === 'number' && opacity >= 0.0 && opacity <= 1.0) {
+    this.group_.setAttribute('opacity', opacity);
+  }
+};
+
+/**
+ * Append children to this layer.
+ * @param {SVGGElement} children - The children to append to this layer.
+ */
+Layer.prototype.appendChildren = function(children) {
+  for (var i = 0; i < children.length; ++i) {
+    this.group_.appendChild(children[i]);
+  }
+};
+
+Layer.prototype.getTitleElement = function() {
+  var len = this.group_.childNodes.length;
+  for (var i = 0; i < len; ++i) {
+    var child = this.group_.childNodes.item(i);
+    if (child && child.tagName === 'title') {
+      return child;
+    }
+  }
+  return null;
+};
+
+Layer.prototype.setName = function(name) {
+  var previousName = this.name_;
+  name = svgedit.utilities.toXml(name);
+  // now change the underlying title element contents
+  var title = this.getTitleElement();
+  if (title) {
+    while (title.firstChild) { title.removeChild(title.firstChild); }
+    title.textContent = name;
+    this.name_ = name;
+    return {title: title, previousName: previousName};
+  }
+  return null;
+};
+
+/**
+ * Remove this layer's group from the DOM. No more functions on group can be called after this.
+ * @param {SVGGElement} children - The children to append to this layer.
+ * @returns {SVGGElement} The layer SVG group that was just removed.
+ */
+Layer.prototype.removeGroup = function() {
+  var parent = this.group_.parentNode;
+  var group = parent.removeChild(this.group_);
+  this.group_ = undefined;
+  return group;
+};
+
+
+/**
+ * Add class Layer.CLASS_NAME to the element (usually class='layer').
+ *
+ * Parameters:
+ * @param {SVGGElement} elem - The SVG element to update
+ */
+function addLayerClass(elem) {
+  var classes = elem.getAttribute('class');
+  if (classes === null || classes === undefined || classes.length === 0) {
+    elem.setAttribute('class', Layer.CLASS_NAME);
+  } else if (! Layer.CLASS_REGEX.test(classes)) {
+    elem.setAttribute('class', classes + ' ' + Layer.CLASS_NAME);
+  }
+}
+
+}());

--- a/editor/svg-editor.html
+++ b/editor/svg-editor.html
@@ -39,10 +39,12 @@
   <script src="svgutils.js"></script>
   <script src="sanitize.js"></script>
   <script src="history.js"></script>
+  <script src="historyrecording.js"></script>
   <script src="coords.js"></script>
   <script src="recalculate.js"></script>
   <script src="select.js"></script>
   <script src="draw.js"></script>
+  <script src="layer.js"></script>
   <script src="path.js"></script>
   <script src="svgcanvas.js"></script>
   <script src="svg-editor.js"></script>

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -1841,7 +1841,7 @@ TODOS
 			 * @returns {boolean} True if the element is a layer
 			 */
 			function isLayer(elem) {
-				return elem && elem.tagName === 'g' && svgedit.LAYER_CLASS_REGEX.test(elem.getAttribute('class'))
+				return elem && elem.tagName === 'g' && svgedit.draw.Layer.CLASS_REGEX.test(elem.getAttribute('class'))
 			}
 
 			// called when any element has changed

--- a/editor/svgedit.js
+++ b/editor/svgedit.js
@@ -15,10 +15,8 @@ svgedit = {
 		XLINK: 'http://www.w3.org/1999/xlink',
 		XML: 'http://www.w3.org/XML/1998/namespace',
 		XMLNS: 'http://www.w3.org/2000/xmlns/' // see http://www.w3.org/TR/REC-xml-names/#xmlReserved
-	},
-	LAYER_CLASS: 'layer'
+	}
 };
-svgedit.LAYER_CLASS_REGEX = new RegExp('(\\s|^)' + svgedit.LAYER_CLASS + '(\\s|$)');
 
 // return the svgedit.NS with key values switched and lowercase
 svgedit.getReverseNS = function() {'use strict';

--- a/test/draw_test.html
+++ b/test/draw_test.html
@@ -6,9 +6,11 @@
   <link rel='stylesheet' href='qunit/qunit.css' type='text/css'/>
   <script src='../editor/jquery.js'></script>
   <script src='../editor/svgedit.js'></script>
+  <script src='../editor/pathseg.js'></script>
   <script src='../editor/browser.js'></script>
   <script src='../editor/svgutils.js'></script>
   <script src='../editor/draw.js'></script>
+  <script src='../editor/layer.js'></script>
   <script src='qunit/qunit.js'></script>
   <script>
   $(function() {
@@ -19,7 +21,7 @@
       }
     };
     var NS = svgedit.NS;
-    var LAYER_CLASS = svgedit.LAYER_CLASS;
+    var LAYER_CLASS = svgedit.draw.Layer.CLASS_NAME;
     var NONCE = 'foo';
     var LAYER1 = 'Layer 1';
     var LAYER2 = 'Layer 2';


### PR DESCRIPTION
New branch from latest master after previous [pull request merge](https://github.com/SVG-Edit/svgedit/pull/106).
Fixed bug with Canvas referencing Drawing.all_layers.
Moved Layer class to layer.js.

#### HistoryRecordingService
Fixed Layers in svgcanvas. Canvas has history and Drawing does not. I also want to get things clean over to Layer, so I need a good, simple history service that I can inject. I came up with  HistoryRecordingService.  See the docs and let me know what you think. See Canvas.mergeLayer and mergeLayers to see how it's used. 

I want to use HistoryRecordingService in Drawing.prototype.setCurrentLayerPosition. It's kluged right now to return {title:SVGGElement, previousName:string} because that's what the history needs. With the new mechanism, I just pass in a HistoryRecordingService.

Need to write some tests for HistoryRecordingService.

#### Commit Notes:
Canvas was referencing drawing.all_layers and drawing.current_layer.
Both variables now represent Layer instead of group element and should
be considered private.
Moved Layer class to layer.js
New HistoryRecordingService added to help with moving Layer code out of
Canvas. Started using it in Canvas.mergeLayer