### PR TITLE
Fixed svgCanvasToString to get latest nsMap for custom namespace support.

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -3698,6 +3698,9 @@ var removeUnusedDefElems = this.removeUnusedDefElems = function() {
 // Returns: 
 // String containing the SVG image for output
 this.svgCanvasToString = function() {
+	// Get the latest NS after any extensions have called sanitize.addWhiteListException().
+	nsMap = svgedit.getReverseNS();
+
 	// keep calling it until there are none to remove
 	while (removeUnusedDefElems() > 0) {}
 	


### PR DESCRIPTION
#### Please review
I'm not sure this the best way to fix this problem? Do you have other suggestions?

This is needed to support extensions that call sanitize.addWhiteListException()
for custom namespace support. I assume this is related to [Issue #94](https://github.com/SVG-Edit/svgedit/issues/94).

svgCanvasToString was using the static nsMap from startup. This doesn't have the latest namespaces added during our extension's calls to sanitize.addWhiteListException(). Without this fix, clicking Save or SVG Source view removes all custom namespaces that were in the DOM.

#### Example Extension:
```
svgedit.editor.addExtension( "ext-fisheye-base", function ( S ) {
   svgedit.sanitize.addWhiteListException("g", 'http://www.totalgrid.org', 'some-attribute');
   ...
}
```