### PR TITLE
Fix for issue #93 - svgEditorReady event is not triggered in an iframe.

### DIFF
--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -798,7 +798,7 @@ TODOS
 			(function() {
 				// let the opener know SVG Edit is ready (now that config is set up)
 				var svgEditorReadyEvent,
-					w = window.opener;
+					w = window.opener || window.parent;
 				if (w) {
 					try {
 						svgEditorReadyEvent = w.document.createEvent('Event');


### PR DESCRIPTION
I accidentally created this patch in the fork's master branch in pull request #95. Here it is in it's own branch. This should solve issue #93.
