### PR TITLE
Add svg element from json expansion

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -189,6 +189,8 @@ var selectedElements = [];
 //
 // Returns: The new element
 var addSvgElementFromJson = this.addSvgElementFromJson = function addSvgElementFromJson(data) {
+	if(typeof(data) == 'string') return svgdoc.createTextNode(data);
+
 	var shape = svgedit.utilities.getElem(data.attr.id);
 	// if shape is a path but we need to create a rect/ellipse, then remove the path
 	var current_layer = getCurrentDrawing().getCurrentLayer();

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -190,7 +190,7 @@ var selectedElements = [];
 //
 // Returns: The new element
 var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
-	if(typeof(data) == 'string') return svgdoc.createTextNode(data);
+	if (typeof(data) == 'string') return svgdoc.createTextNode(data);
 
 	var shape = svgedit.utilities.getElem(data.attr.id);
 	// if shape is a path but we need to create a rect/ellipse, then remove the path
@@ -223,7 +223,7 @@ var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
 	svgedit.utilities.cleanupElement(shape);
 
 	// Children
-	if(data.children) {
+	if (data.children) {
 		data.children.forEach(function(child) {
 			shape.appendChild(addSvgElementFromJson(child));
 		});

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -189,7 +189,7 @@ var selectedElements = [];
 // * children - Optional array with data objects to be added recursively as children
 //
 // Returns: The new element
-var addSvgElementFromJson = this.addSvgElementFromJson = function addSvgElementFromJson(data) {
+var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
 	if(typeof(data) == 'string') return svgdoc.createTextNode(data);
 
 	var shape = svgedit.utilities.getElem(data.attr.id);

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -223,9 +223,11 @@ var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
 	svgedit.utilities.cleanupElement(shape);
 
 	// Children
-	if(data.children) data.children.forEach(function(child){
-		shape.appendChild(addSvgElementFromJson(child));
-	});
+	if(data.children) {
+		data.children.forEach(function(child) {
+			shape.appendChild(addSvgElementFromJson(child));
+		});
+	}
 
 	return shape;
 };

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -188,7 +188,7 @@ var selectedElements = [];
 // * curStyles - Boolean indicating that current style attributes should be applied first
 //
 // Returns: The new element
-var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
+var addSvgElementFromJson = this.addSvgElementFromJson = function addSvgElementFromJson(data) {
 	var shape = svgedit.utilities.getElem(data.attr.id);
 	// if shape is a path but we need to create a rect/ellipse, then remove the path
 	var current_layer = getCurrentDrawing().getCurrentLayer();
@@ -218,6 +218,12 @@ var addSvgElementFromJson = this.addSvgElementFromJson = function(data) {
 	}
 	svgedit.utilities.assignAttributes(shape, data.attr, 100);
 	svgedit.utilities.cleanupElement(shape);
+
+	// Children
+	if(data.children) data.children.forEach(function(child){
+		shape.appendChild(addSvgElementFromJson(child));
+	});
+
 	return shape;
 };
 

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -186,6 +186,7 @@ var selectedElements = [];
 // * element - tag name of the SVG element to create
 // * attr - Object with attributes key-values to assign to the new element
 // * curStyles - Boolean indicating that current style attributes should be applied first
+// * children - Optional array with data objects to be added recursively as children
 //
 // Returns: The new element
 var addSvgElementFromJson = this.addSvgElementFromJson = function addSvgElementFromJson(data) {


### PR DESCRIPTION
I've simplified adding svg in json format. Instead of adding 1 svg element at a time, you can include children in the json input. E.g.:

```
    var node = addSvgElementFromJson({
        'element': 'g',
        'attr': {
            'id': 'group123'
        },
        'children': [
            {
                'element': 'path',
                'attr': {
                    'id': 'box123',
                    'fill': 'none',
                    'style': 'pointer-events:none'
                }
            },
            'And now a text node can be created with just a string.'
        ]
    });
```
