### PR TITLE
Optimized loading by removing unnecessary code

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -4513,16 +4513,6 @@ this.setSvgString = function(xmlString) {
 		
 		convertGradients(content[0]);
 		
-		// recalculate dimensions on the top-level children so that unnecessary transforms
-		// are removed
-		svgedit.utilities.walkTreePost(svgcontent, function(n) {
-			try {
-				svgedit.recalculate.recalculateDimensions(n);
-			} catch(e) {
-				console.log(e);
-			}
-		});
-		
 		var attrs = {
 			id: 'svgcontent',
 			overflow: curConfig.show_outside_canvas ? 'visible' : 'hidden'


### PR DESCRIPTION
Removed code which went through all nodes and recalculated dimensions,
which was a lot of work for large svg drawings. There's no need to do
that when loading. It will happen gradually when you use it and on
manageable parts. This changed the loading time for a page with svg-edit
and a large drawing from ~50 secs to ~5 secs.