### PR TITLE
Log errors from extensions to the browser console.

### DIFF
--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -557,6 +557,8 @@ TODOS
 							s.src = curConfig.extPath + extname;
 							document.querySelector('head').appendChild(s);
 						}
+					}).fail(function(jqxhr, settings, exception){
+						console.log(exception);
 					});
 				});
 


### PR DESCRIPTION
Errors in extensions were just ignored before.