### PR TITLE
SVG validity check in svgCanvas.setSvgString()

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -4446,6 +4446,8 @@ this.setSvgString = function(xmlString) {
 	try {
 		// convert string into XML document
 		var newDoc = svgedit.utilities.text2xml(xmlString);
+		if(newDoc.firstChild.namespaceURI != 'http://www.w3.org/2000/svg')
+			return false;
 
 		this.prepareSvg(newDoc);
 


### PR DESCRIPTION
Added a check for valid svg (or at least the namespace), so we can return false right away, instead of relying on it to be caught in a try/catch with a not so descriptive error message.