### PR TITLE
Bind extensions click events as mousedown (touch devices)

### DIFF
--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -2773,6 +2773,13 @@ TODOS
 							// Add given events to button
 							$.each(btn.events, function(name, func) {
 								if (name == 'click' && btn.type == 'mode') {
+									/*
+									* For touch devices, convert the click event to mousedown
+									* Works the same as the the binding of "regular" buttons (line 4597), but here for extensions
+									*/
+									if (svgedit.browser.isTouch() && name == 'click') {
+										name = 'mousedown';
+									}
 									if (btn.includeWith) {
 										button.bind(name, func);
 									} else {


### PR DESCRIPTION
On touch devices the click event is not used, instead touch.js fallbacks
to mousedown.

Thus extension buttons listening to "click" could not be selected nor extension tools used (as
panning, color picking, star shape) on a touch device (or even touch emulation in google chrome).

If svg recognize a touch device, click events for extensions are now bind as
mousedown.