### PR TITLE
Add composer.js to let PHP developers to keep track of svgedit on packagist.org

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,38 @@
+{
+    "name": "svg-edit/svgedit",
+    "description": "SVG-edit is a fast, web-based, javascript-driven SVG drawing editor that works in any modern browser.",
+    "authors": [
+        {
+            "name":"Narendra Sisodiya",
+            "email": "narendra@narendrasisodiya.com"
+        },
+        {
+            "name":"Pavol Rusnak",
+            "email": "stick@gk2.sk"
+        },
+        {
+            "name":"Jeff Schiller",
+            "email": "codedread@gmail.com"
+        },
+        {
+            "name":"Vidar Hokstad",
+            "email": "vidar.hokstad@gmail.com"
+        },
+        {
+            "name":"Alexis Deveria",
+            "email": "adeveria@gmail.com"
+        }
+    ],
+    "keywords": [
+        "svg",
+        "svg-edit",
+        "drawing",
+        "editor"
+    ],
+    "type": "library",
+    "license": "MIT",
+    "minimum-stability": "stable",
+    "homepage": "https://github.com/SVG-Edit/svgedit/tree/master",
+    "require": {
+    }
+}


### PR DESCRIPTION
Hello!

SVG-Edit is a very nice tool!! If you could provide the composer.json for this library, PHP developers could keep track of your development and reference `svg-edit/svgedit` as a dependency available on packagist.org.

I did this pull request with `composer.json`. Unfortunately, there is some tasks I can't do for you, like submit this package in packagist.org and wire github webhooks.

Another thing particular to your repository is about tag names. Packagist didn't recognize your release branches as tags, but it is easy to solve!! This was commands I typed to create tags for you repository.  :)

```
git tag v1.0 origin/1.0
git tag v2.1   origin/2.1
git tag v2.2   origin/2.2
git tag v2.3   origin/2.3
git tag v2.4   origin/2.4
git tag v2.5   origin/2.5
git tag v2.5.1 origin/2.5.1
git tag v2.6   origin/2.6
git tag v2.7   origin/2.7
git tag v2.8.1 svg-edit-2.8.1
```

Many javascript developers make their packages available on packagist.org, for example

https://packagist.org/packages/twbs/bootstrap
https://packagist.org/packages/components/jquery
https://packagist.org/packages/components/jqueryui
https://packagist.org/packages/blueimp/jquery-file-upload
https://packagist.org/packages/ckeditor/ckeditor
https://packagist.org/packages/mbostock/d3
https://packagist.org/packages/tinymce/tinymce
https://packagist.org/packages/moment/moment
https://packagist.org/packages/plotly/plotly.js

It would be awesome to have your package on packagist too. :smiley: 