### PR TITLE
changed fhpath onMouseMove code to use a hopefully faster method

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -1832,8 +1832,18 @@ var getMouseTarget = this.getMouseTarget = function(evt) {
 						sumDistance += Math.sqrt((nextPos.x - bSpline.x) * (nextPos.x - bSpline.x) + (nextPos.y - bSpline.y) * (nextPos.y - bSpline.y));
 						if (sumDistance > THRESHOLD_DIST) {
 							d_attr += + bSpline.x + ',' + bSpline.y + ' ';
-							shape.setAttributeNS(null, 'points', d_attr);
 							sumDistance -= THRESHOLD_DIST;
+							
+							// Instead of setting the points attribute, use the below method
+							//shape.setAttributeNS(null, 'points', d_attr);
+							
+							// This may be faster than completely re-writing the points attribute.
+							// Should be tested for speed comparison.
+							var point = svgcontent.createSVGPoint();
+							point.x = bSpline.x;
+							point.y = bSpline.y;
+							shape.points.appendItem(point);
+						
 						}
 					}
 				}


### PR DESCRIPTION
This pull request changes how the path is drawn during onMouseMove while using the freehand path tool. Instead of adding the points to the d_attr string the native SVG method is used to add the points to the polyline. Hopefully this can improve the performance of the freehand path tool which has noticeable framerate issues when drawing a very long path. If this pull request makes it to master branch, we can also remove the d_attr variable.

I've only tested on Firefox 52 and Chromium 57 on Linux. It seems faster on Chromium, but I don't have hard numbers to show it. Theoretically it should be faster though.