### PR TITLE
Fix documentation markdown

### DIFF
--- a/docs/Acknowledgements.md
+++ b/docs/Acknowledgements.md
@@ -17,21 +17,21 @@ Jeff Schiller created the excellent [jGraduate](https://code.google.com/p/jgradu
 #### canvg
 Gabe Lerner's excellent [canvg](https://github.com/gabelerner/canvg) library has helped us bypass browsers' inability to save SVG files an PNGs, by first rendering SVG images in an HTML5 Canvas element.
 
-####jQuery UI
+#### jQuery UI
 
 We use [jQuery-UI](http://jqueryui.com) for making the dialog boxes (color picker, document properties) draggable, as well as for the opacity slider.
 
-####js-hotkeys
+#### js-hotkeys
 
 [js-hotkeys](https://github.com/jeresig/jquery.hotkeys) is used to bind all keyboard events in the editor.
 
-####JQuery Web Spin-Button
+#### JQuery Web Spin-Button
 
 George Adamson's [Web Spin-Button](http://www.softwareunity.com/jquery/JQuerySpinBtn) provided a starting point to implementing a cross-browser spin control in SVG-edit. A few bugs were fixed with compatibility and sent back to George for hopeful inclusion in the next version of his jQuery plugin.
 
-####SVG Icon Loader
+#### SVG Icon Loader
 Alexis Deveria's [svg-icon-loader](https://code.google.com/p/svg-icon-loader/) is used to load in all the SVG icons for the SVG-edit user interface.
 
-####Icons
+#### Icons
 
 Many of the icons used in SVG-edit come from the [Tango Desktop Project](http://tango.freedesktop.org/Tango_Desktop_Project) which are released into the public domain. We also used a couple of icons from the [Silk Icon Project](http://famfamfam.com/lab/icons/silk), which is licensed under the Creative Commons Attribution 2.5 License. Finally, some of the icons were hand-drawn (in SVG-edit itself).

--- a/docs/SvgCanvas.md
+++ b/docs/SvgCanvas.md
@@ -2,14 +2,14 @@
 
 The main SvgCanvas class that manages all SVG-related functions
 
-##Parameters
+## Parameters
 
 * `container` The container HTML element that should hold the SVG root element
 * `config` An object that contains configuration data
 
-##Summary
+## Summary
 
-###SvgCanvas - The main SvgCanvas class that manages all SVG-related functions 
+### SvgCanvas - The main SvgCanvas class that manages all SVG-related functions 
 
 Function | Description
 ---------|------------
@@ -22,7 +22,7 @@ Function | Description
 [`snapToAngle`](#snaptoangle) | Returns a 45 degree angle coordinate associated with the two given coordinates
 [`text2xml`](#text2xml) | Cross-browser compatible method of converting a string to an XML tree found this function [here](http://groups.google.com/group/jquery-dev/browse_thread/thread/c6d11387c580a77f)
 
-###Unit conversion functions
+### Unit conversion functions
 
 Function | Descrption
 ---------|-----------
@@ -30,7 +30,7 @@ Function | Descrption
 [`setUnitAttr`](#setunitattr) | Sets an element’s attribute based on the unit in its current value.
 [`isValidUnit`](#isvalidunit) | Check if an attribute’s value is in a valid format
 
-###Undo/Redo history management
+### Undo/Redo history management
 
 Function | Description
 ---------|------------
@@ -67,7 +67,7 @@ Function | Description
 [`beginUndoableChange`](#beginundoablechange) | This function tells the canvas to remember the old values of the attrName attribute for each element sent in.
 [`finishUndoableChange`](#finishundoablechange) | This function returns a BatchCommand object which summarizes the change since `beginUndoableChange` was called.
 
-###[`Selector`](#selector) - Private class for DOM element selection boxes
+### [`Selector`](#selector) - Private class for DOM element selection boxes
 
 Function | Description
 ---------|------------
@@ -76,7 +76,7 @@ Function | Description
 [`Selector.updateGripCursors`](selectorupdategripcursors) | Updates cursors for corner grips on rotation so arrows point the right way
 [`Selector.resize`](#selectorresize) | Updates the selector to match the element’s size
 
-###[`SelectorManager`](#selectormanager) - Public class to manage all selector objects (selection boxes)
+### [ `SelectorManager`](#selectormanager) - Public class to manage all selector objects (selection boxes)
 
 Function | Description
 ---------|------------
@@ -85,7 +85,7 @@ Function | Description
 [`SelectorManager.releaseSelector`](#selectormanagerreleaseselector) | Removes the selector of the given element (hides selection box)
 [`SelectorManager.getRubberBandBox`](#selectormanagergetrubberbandbox`) | Returns the rubberBandBox DOM element.
 
-###Helper functions	
+### Helper functions	
 
 Function | Description
 ---------|------------
@@ -110,7 +110,7 @@ Function | Description
 [`ffClone`](#ffclone) | Hack for Firefox bugs where text element features aren't updated.
 [`getPathBBox`](#getpathbbox) | Get correct BBox for a path in Webkit Converted from code found [here](http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html)
 
-###Element Transforms	
+### Element Transforms	
 
 Function | Description
 ---------|------------
@@ -128,7 +128,7 @@ Function | Description
 [`getMatrix`](#getmatrix) | Get the matrix object for a given element
 [`transformBox`](#transformbox) | Transforms a rectangle based on the given matrix
 
-###Selection
+### Selection
 	
 Function | Description
 ---------|------------
@@ -140,11 +140,11 @@ Function | Description
 [`getMouseTarget`](#getmousetarget) | Gets the desired element from a mouse event
 [`preventClickDefault`](#preventclickdefault) | Prevents default browser click behaviour on the given element
 
-###Text edit functions - Functions relating to editing text elements
+### Text edit functions - Functions relating to editing text elements
 
-###Path edit functions - Functions relating to editing path elements
+### Path edit functions - Functions relating to editing path elements
 
-###Serialization	
+### Serialization	
 
 Function | Description
 ---------|------------
@@ -158,7 +158,7 @@ Function | Description
 [`setSvgString`](#setsvgstring) | This function sets the current drawing as the input SVG XML.
 [`importSvgString`](#importsvgstring) | This function imports the input SVG XML into the current layer in the drawing
 
-###Layers	
+### Layers	
 
 Function | Description
 ---------|------------
@@ -177,7 +177,7 @@ Function | Description
 [`getLayerOpacity`](#getlayeropacity) | Returns the opacity of the given layer.
 [`setLayerOpacity`](#setlayeropacity) | Sets the opacity of the given layer.
 
-###Document functions	
+### Document functions	
 
 Function | Description
 ---------|------------
@@ -201,7 +201,7 @@ Function | Description
 [`getMode`](#getmode) | Returns the current editor mode string
 [`setMode`](#setmode) | Sets the editor’s mode to the given string
 
-###Element Styling	
+### Element Styling	
 
 Function | Description
 ---------|------------
@@ -236,7 +236,7 @@ Function | Description
 [`setImageURL`](#setimageurl) | Sets the new image URL for the selected image element.
 [`setRectRadius`](#setrectradius) | Sets the rx & ry values to the selected rect element to change its corner radius
 
-###Element manipulation	
+### Element manipulation	
 
 Function | Description
 ---------|------------
@@ -253,7 +253,7 @@ Function | Description
 [`cloneSelectedElements`](#cloneselectedelements) | Create deep DOM copies (clones) of all selected elements and move them slightly from their originals
 [`alignSelectedElements`](#alignselectedelements) | Aligns selected elements
 
-###Additional editor tools	
+### Additional editor tools	
 
 Function | Description
 ---------|------------
@@ -261,320 +261,320 @@ Function | Description
 [`setBackground`](#setbackground) | Set the background of the editor (NOT the actual document)
 [`cycleElement`](#cycleelement) | Select the next/previous element within the current layer
 
-##`Utils.toXml`
+## `Utils.toXml`
 
 Converts characters in a string to XML-friendly entities. Example: `&` becomes `&amp;`
 
-####Parameters
+#### Parameters
 
 `str` The string to be converted
 
-####Returns
+#### Returns
 
 The converted string
 
-##`Utils.fromXml`
+## `Utils.fromXml`
 
 Converts XML entities in a string to single characters. Example: `&amp;` becomes `&`
 
-####Parameters
+#### Parameters
 
 `str` The string to be converted
 
-####Returns
+#### Returns
 
 The converted string 
 
-##`Utils.encode64`
+## `Utils.encode64`
 Converts a string to base64
 
-##`Utils.decode64`
+## `Utils.decode64`
 Converts a string from base64
 
-##`Utils.convertToXMLReferences`
+## `Utils.convertToXMLReferences`
 Converts a string to use XML references
 
-##`rectsIntersect`
+## `rectsIntersect`
 
 	"rectsIntersect": function( r1,r2 )
 
 Check if two rectangles (BBoxes objects) intersect each other
 
-####Paramaters
+#### Paramaters
 
 `r1` The first BBox-like object
 `r2` The second BBox-like object
 
-####Returns
+#### Returns
 
 Boolean that’s true if rectangles intersect
 
-##`snapToAngle`
+## `snapToAngle`
 
 	"snapToAngle": function( x1, y1, x2, y2 )
 	
 Returns a 45 degree angle coordinate associated with the two given coordinates
 
-####Parameters
+#### Parameters
 
 * `x1` First coordinate’s x value
 * `x2` Second coordinate’s x value
 * `y1` First coordinate’s y value
 * `y2` Second coordinate’s y value
 
-####Returns
+#### Returns
 
 Object with the following values: x - The angle-snapped x value y - The angle-snapped y value snapangle - The angle at which to snap
 
-##`text2xml`
+## `text2xml`
 
 	"text2xml": function(sXML)
 
 Cross-browser compatible method of converting a string to an XML tree found this function [here](http://groups.google.com/group/jquery-dev/browse_thread/thread/c6d11387c580a77f)
 
-#Unit conversion functions
+# Unit conversion functions
 
-##`convertToNum`
+## `convertToNum`
 
 	convertToNum = function( attr, val )
 
 Converts given values to numbers.  Attributes must be supplied in case a percentage is given
 
-####Parameters
+#### Parameters
 
 * `attr` String with the name of the attribute associated with the value
 * `val` String with the attribute value to convert
 
-##`setUnitAttr`
+## `setUnitAttr`
 
 	setUnitAttr = function( elem, attr, val )
 
 Sets an element’s attribute based on the unit in its current value.
 
-####Parameters
+#### Parameters
 
 * `elem` DOM element to be changed
 * `attr` String with the name of the attribute associated with the value
 * `val` String with the attribute value to convert
 
-##`isValidUnit`
+## `isValidUnit`
 
 	canvas.isValidUnit = function( attr,val )
 
 Check if an attribute’s value is in a valid format
 
-####Parameters
+#### Parameters
 
 * `attr` String with the name of the attribute associated with the value
 * `val` String with the attribute value to check
 
-#Undo/Redo history management
+# Undo/Redo history management
 
-##`ChangeElementCommand`
+## `ChangeElementCommand`
 
 	var ChangeElementCommand = this.undoCmd.changeElement = function( elem, attrs, text )
 
 History command to make a change to an element.  Usually an attribute change, but can also be textcontent.
 
-####Parameters
+#### Parameters
 
 * `elem` The DOM element that was changed
 * `attrs` An object with the attributes to be changed and the values they had before the change
 * `text` An optional string visible to user related to this change
 
-##`ChangeElementCommand.apply`
+## `ChangeElementCommand.apply`
 
 Performs the stored change action
 
-##`ChangeElementCommand.unapply`
+## `ChangeElementCommand.unapply`
 
 Reverses the stored change action
 
-##`ChangeElementCommand.elements`
+## `ChangeElementCommand.elements`
 
 Returns array with element associated with this command
 
-##`InsertElementCommand`
+## `InsertElementCommand`
 
 	var InsertElementCommand = this.undoCmd.insertElement = function( elem, text )
 
 History command for an element that was added to the DOM
 
-####Parameters
+#### Parameters
 
 * `elem	` The newly added DOM element
 * `text` An optional string visible to user related to this change
 
-##`InsertElementCommand.apply`
+## `InsertElementCommand.apply`
 
 Re-Inserts the new element
 
-##`InsertElementCommand.unapply`
+## `InsertElementCommand.unapply`
 
 Removes the element
 
-##`InsertElementCommand.elements`
+## `InsertElementCommand.elements`
 
 Returns array with element associated with this command
 
-##`RemoveElementCommand`
+## `RemoveElementCommand`
 
 	var RemoveElementCommand = this.undoCmd.removeElement = function( elem, parent, text )
 
 History command for an element removed from the DOM
 
-####Parameters
+#### Parameters
 * `elem	` The removed DOM element
 * `parent` The DOM element’s parent
 * `text` An optional string visible to user related to this change
 
-##`RemoveElementCommand.apply`
+## `RemoveElementCommand.apply`
 
 Re-removes the new element
 
-##`RemoveElementCommand.unapply`
+## `RemoveElementCommand.unapply`
 
 Re-adds the new element
 
-##`RemoveElementCommand.elements`
+## `RemoveElementCommand.elements`
 
 Returns array with element associated with this command
 
-##`MoveElementCommand`
+## `MoveElementCommand`
 
 	var MoveElementCommand = this.undoCmd.moveElement = function( elem, oldNextSibling, oldParent, text )
 
 History command for an element that had its DOM position changed
 
-####Parameters
+#### Parameters
 
 * `elem	` The DOM element that was moved
 * `oldNextSibling` The element’s next sibling before it was moved
 * `oldParent` The element’s parent before it was moved
 * `text` An optional string visible to user related to this change
 
-##`MoveElementCommand.unapply`
+## `MoveElementCommand.unapply`
 
 Re-positions the element
 
-##`MoveElementCommand.unapply`
+## `MoveElementCommand.unapply`
 
 Positions the element back to its original location
 
-##`MoveElementCommand.elements`
+## `MoveElementCommand.elements`
 
 Returns array with element associated with this command
 
-##`BatchCommand`
+## `BatchCommand`
 
 	var BatchCommand = this.undoCmd.batch = function( text )
 
 History command that can contain/execute multiple other commands
 
-####Parameters
+#### Parameters
 
 * `text` An optional string visible to user related to this change
 
-##`BatchCommand.apply`
+## `BatchCommand.apply`
 
 Runs “apply” on all subcommands
 
-##`BatchCommand.unapply`
+## `BatchCommand.unapply`
 
 Runs “unapply” on all subcommands
 
-##`BatchCommand.elements`
+## `BatchCommand.elements`
 
 Iterate through all our subcommands and returns all the elements we are changing
 
-##`BatchCommand.addSubCommand`
+## `BatchCommand.addSubCommand`
 
 Adds a given command to the history stack
 
-####Parameters
+#### Parameters
 
 * `cmd` The undo command object to add
 
-##`BatchCommand.isEmpty`
+## `BatchCommand.isEmpty`
 
 Returns a boolean indicating whether or not the batch command is empty
 
-##`resetUndoStack`
+## `resetUndoStack`
 
 	resetUndoStack = function()
 
 Resets the undo stack, effectively clearing the undo/redo history
 
-##`undoMgr.getUndoStackSize`
+## `undoMgr.getUndoStackSize`
 
-####Returns
+#### Returns
 Integer with the current size of the undo history stack
 
-##`undoMgr.getRedoStackSize`
+## `undoMgr.getRedoStackSize`
 
-####Returns
+#### Returns
 
 Integer with the current size of the redo history stack
 
-##`undoMgr.getNextUndoCommandText`
+## `undoMgr.getNextUndoCommandText`
 
-####Returns
+#### Returns
 
 String associated with the next undo command
 
-##`undoMgr.getNextRedoCommandText`
+## `undoMgr.getNextRedoCommandText`
 
-####Returns
+#### Returns
 
 String associated with the next redo command
 
-##`undoMgr.undo`
+## `undoMgr.undo`
 
 Performs an undo step
 
-##`undoMgr.redo`
+## `undoMgr.redo`
 
 Performs a redo step
 
-##`addCommandToHistory`
+## `addCommandToHistory`
 
 	addCommandToHistory = c.undoCmd.add = function( cmd )
 
 Adds a command object to the undo history stack
 
-####Parameters
+#### Parameters
 
 * `cmd` The command object to add
 
-##`beginUndoableChange`
+## `beginUndoableChange`
 
 	c.beginUndoableChange = function( attrName, elems )
 
 This function tells the canvas to remember the old values of the attrName attribute for each element sent in.  The elements and values are stored on a stack, so the next call to `finishUndoableChange()` will pop the elements and old values off the stack, gets the current values from the DOM and uses all of these to construct the undo-able command.
 
-####Parameters
+#### Parameters
 
 * `attrName` The name of the attribute being changed
 * `elems` Array of DOM elements being changed
 
-##`finishUndoableChange`
+## `finishUndoableChange`
 
 	c.finishUndoableChange = function()
 
 This function returns a BatchCommand object which summarizes the change since beginUndoableChange was called. The command can then be added to the command history
 
-####Returns
+#### Returns
 Batch command object with resulting changes
 
-##`Selector`
+## `Selector`
 
 Private class for DOM element selection boxes
 
-####Parameters
+#### Parameters
 * `id` integer to internally indentify the selector
 * `elem` DOM element associated with this selector
 
-####Summary
+#### Summary
 
 Function | Description
 ---------|------------
@@ -583,40 +583,40 @@ Function | Description
 [`Selector.updateGripCursors`](selectorupdategripcursors) | Updates cursors for corner grips on rotation so arrows point the right way
 [`Selector.resize`](#selectorresize) | Updates the selector to match the element’s size
 
-##Functions
+## Functions
 
-##`Selector.reset`
+## `Selector.reset`
 
 Used to reset the id and element that the selector is attached to
 
-####Parameters
+#### Parameters
 
 * `e` DOM element associated with this selector
 
-##`Selector.showGrips`
+## `Selector.showGrips`
 
 Show the resize grips of this selector
 
-####Parameters
+#### Parameters
 * `show` boolean indicating whether grips should be shown or not
 
-##`Selector.updateGripCursors`
+## `Selector.updateGripCursors`
 
 Updates cursors for corner grips on rotation so arrows point the right way
 
-####Parameters
+#### Parameters
 
 * `angle` Float indicating current rotation angle in degrees
 
-##`Selector.resize`
+## `Selector.resize`
 
 Updates the selector to match the element’s size
 
-##`SelectorManager`
+## `SelectorManager`
 
 Public class to manage all selector objects (selection boxes)
 
-##Summary
+## Summary
 
 Function | Description
 ---------|------------
@@ -625,221 +625,221 @@ Function | Description
 [`SelectorManager.releaseSelector`](#selectormanagerreleaseselector) | Removes the selector of the given element (hides selection box)
 [`SelectorManager.getRubberBandBox`](#selectormanagergetrubberbandbox`) | Returns the rubberBandBox DOM element.
 
-##`SelectorManager.initGroup`
+## `SelectorManager.initGroup`
 
 Resets the parent selector group element
 
-##`SelectorManager.requestSelector`
+## `SelectorManager.requestSelector`
 
 Returns the selector based on the given element
 
-####Parameters
+#### Parameters
 
 * `elem` DOM element to get the selector for
 
-##`SelectorManager.releaseSelector`
+## `SelectorManager.releaseSelector`
 
 Removes the selector of the given element (hides selection box)
 
-####Parameters
+#### Parameters
 
 * `elem` DOM element to remove the selector for
 
-##`SelectorManager.getRubberBandBox`
+## `SelectorManager.getRubberBandBox`
 
 Returns the rubberBandBox DOM element.  This is the rectangle drawn by the user for selecting/zooming
 
-#Helper functions
+# Helper functions
 
-##`walkTree`
+## `walkTree`
 
 	function walkTree( elem, cbFn )
 
 Walks the tree and executes the callback on each element in a top-down fashion
 
-####Parameters
+#### Parameters
 
 * `elem` DOM element to traverse
 * `cbFn` Callback function to run on each element
 
-##`walkTreePost`
+## `walkTreePost`
 
 	function walkTreePost( elem, cbFn )
 
 Walks the tree and executes the callback on each element in a depth-first fashion
 
-####Parameters
+#### Parameters
 
 * `elem	` DOM element to traverse
 * `cbFn` Callback function to run on each element
 
-##`assignAttributes`
+## `assignAttributes`
 
 	var assignAttributes = this.assignAttributes = function( node, attrs, suspendLength, unitCheck )
 
 Assigns multiple attributes to an element.
 
-####Parameters
+#### Parameters
 
 * `node` DOM element to apply new attribute values to
 * `attrs` Object with attribute keys/values
 * `suspendLength` Optional integer of milliseconds to suspend redraw
 * `unitCheck` Boolean to indicate the need to use setUnitAttr
 
-##`cleanupElement`
+## `cleanupElement`
 
 	var cleanupElement = this.cleanupElement = function( element )
 
 Remove unneeded (default) attributes, makes resulting SVG smaller
 
-####Parameters
+#### Parameters
 
 * `element` DOM element to clean up
 
-##`addSvgElementFromJson`
+## `addSvgElementFromJson`
 
 	var addSvgElementFromJson = this.addSvgElementFromJson = function( data )
 
 Create a new SVG element based on the given object keys/values and add it to the current layer The element will be ran through `cleanupElement` before being returned
 
-####Parameters
+#### Parameters
 
 * `data` Object with the following keys/values:
 	* `element` - DOM element to create
 	* `attr` - Object with attributes/values to assign to the new element
 	* `curStyles` - Boolean indicating that current style attributes should be applied first
 
-####Returns
+#### Returns
 
 The new element
 
-##`addExtension`
+## `addExtension`
 
 	this.addExtension = function( name, ext_func )
 
 Add an extension to the editor
 
-####Parameters
+#### Parameters
 
 * `name` String with the ID of the extension
 * `ext_func` Function supplied by the extension with its data
 
-##`shortFloat`
+## `shortFloat`
 
 	var shortFloat = function( val )
 
 Rounds a given value to a float with number of digits defined in save_options
 
-####Parameters
+#### Parameters
 
 * `val` The value as a String, Number or Array of two numbers to be rounded
 
-####Returns
+#### Returns
 
 If a string/number was given, returns a Float. If an array, return a string with comma-seperated floats
 
-##`getStrokedBBox`
+## `getStrokedBBox`
 
 	var getStrokedBBox = this.getStrokedBBox = function( elems )
 
 Get the bounding box for one or more stroked and/or transformed elements
 
-####Parameters
+#### Parameters
 
 * `elems` Array with DOM elements to check
 
-####Returns
+#### Returns
 
 A single bounding box object
 
-##`getVisibleElements`
+## `getVisibleElements`
 
 	var getVisibleElements = this.getVisibleElements = function( parent, includeBBox )
 
 Get all elements that have a BBox (excludes `<defs>`, `<title>`, etc).  Note that 0-opacity, off-screen etc elements are still considered “visible” for this function
 
-####Parameters
+#### Parameters
 
 * `parent` The parent DOM element to search within
 * `includeBBox` Boolean to indicate that an object should return with the element and its bbox
 
-####Returns
+#### Returns
 
 An array with all “visible” elements, or if includeBBox is true, an array with objects that include:
 
 * `elem` - The element
 * `bbox` - The element’s BBox as retrieved from getStrokedBBox
 
-##`copyElem`
+## `copyElem`
 
 	var copyElem = function( el )
 
 Create a clone of an element, updating its ID and its children’s IDs when needed
 
-####Parameters
+#### Parameters
 
 * `el` DOM element to clone
 
-####Returns
+#### Returns
 The cloned element
 
-##`getElem`
+## `getElem`
 
 	function getElem( id )
 
 Get a DOM element by ID within the SVG root element.
 
-####Parameters
+#### Parameters
 
 * `id` String with the element’s new ID
 
-##`getId`
+## `getId`
 
 	getId = c.getId = function()
 
 Returns the last created DOM element ID string
 
-##`getNextId`
+## `getNextId`
 
 	getNextId = c.getNextId = function()
 
 Creates and returns a unique ID string for a DOM element
 
-##`bind`
+## `bind`
 
 	c.bind = function( event, f )
 
 Attaches a callback function to an event
 
-####Parameters
+#### Parameters
 
 * `event` String indicating the name of the event
 * `f` The callback function to bind to the event
 
-####Returns
+#### Returns
 
 The previous event
 
-##`setIdPrefix`
+## `setIdPrefix`
 
 	c.setIdPrefix = function( p )
 
 Changes the ID prefix to the given value
 
-####Parameters
+#### Parameters
 * `p` String with the new prefix
 
-##`sanitizeSvg`
+## `sanitizeSvg`
 
 	var sanitizeSvg = this.sanitizeSvg = function( node )
 
 Sanitizes the input node and its children It only keeps what is allowed from our whitelist defined above
 
-####Parameters
+#### Parameters
 
 * `node` The DOM element to be checked, will also check its children
 
-##`getUrlFromAttr`
+## `getUrlFromAttr`
 
 	var getUrlFromAttr = this.getUrlFromAttr = function( attrVal )
 
@@ -849,25 +849,25 @@ Extracts the URL from the `url(...)` syntax of some attributes.  Three variants:
 * `<circle fill="url(‘someFile.svg#foo’)" />`
 * `<circle fill=’url("someFile.svg#foo")’ />`
 
-####Parameters
+#### Parameters
 
 * `attrVal` The attribute value as a string
 
-####Returns
+#### Returns
 
 String with just the URL, like `someFile.svg#foo`
 
-##`getBBox`
+## `getBBox`
 
 	var getBBox = this.getBBox = function( elem )
 
 Get the given/selected element’s bounding box object, convert it to be more usable when necessary
 
-####Parameters
+#### Parameters
 
 * `elem` Optional DOM element to get the BBox for
 
-##`ffClone`
+## `ffClone`
 
 	var ffClone = function( elem )
 
@@ -875,182 +875,182 @@ Hack for Firefox bugs where text element features aren’t updated. This functio
 
 > TODO: Test for this bug on load and add it to “support” object instead of browser sniffing
 
-####Parameters
+#### Parameters
 
 * `elem` The (text) DOM element to clone
 
-##`getPathBBox`
+## `getPathBBox`
 
 	var getPathBBox = function( path )
 
 Get correct BBox for a path in Webkit Converted from code found [here](http://blog.hackers-cafe.net/2009/06/how-to-calculate-bezier-curves-bounding.html)
 
-####Parameters
+#### Parameters
 
 * `path` The path DOM element to get the BBox for
 
-####Returns
+#### Returns
 A BBox-like object
 
-#Element Transforms
+# Element Transforms
 
-##`getRotationAngle`
+## `getRotationAngle`
 
 	var getRotationAngle = this.getRotationAngle = function( elem, to_rad )
 
 Get the rotation angle of the given/selected DOM element
 
-####Parameters
+#### Parameters
 
 * `elem` Optional DOM element to get the angle for
 * `to_rad` Boolean that when true returns the value in radians rather than degrees
 
-####Returns
+#### Returns
 
 Float with the angle in degrees or radians
 
-##`setRotationAngle`
+## `setRotationAngle`
 
 	this.setRotationAngle = function( val, preventUndo )
 
 Removes any old rotations if present, prepends a new rotation at the transformed center
 
-####Parameters
+#### Parameters
 
 * `val` The new rotation angle in degrees
 * `preventUndo` Boolean indicating whether the action should be undoable or not
 
-##`getTransformList`
+## `getTransformList`
 
 	var getTransformList = this.getTransformList = function( elem )
 
 Returns an object that behaves like a SVGTransformList for the given DOM element
 
-####Parameters
+#### Parameters
 
 * `elem` DOM element to get a transformlist from
 
-##`recalculateAllSelectedDimensions`
+## `recalculateAllSelectedDimensions`
 
 	var recalculateAllSelectedDimensions = this.recalculateAllSelectedDimensions = function()
 
 Runs recalculateDimensions on the selected elements, adding the changes to a single batch command
 
-##`remapElement`
+## `remapElement`
 
 	var remapElement = this.remapElement = function( selected, changes, m )
 
 Applies coordinate changes to an element based on the given matrix
 
-####Parameters
+#### Parameters
 
 * `selected` DOM element to be changed
 * `changes` Object with changes to be remapped
 * `m` Matrix object to use for remapping coordinates
 
-##`recalculateDimensions`
+## `recalculateDimensions`
 
 	var recalculateDimensions = this.recalculateDimensions = function( selected )
 
 Decides the course of action based on the element’s transform list
 
-####Parameters
+#### Parameters
 
 * `selected` The DOM element to recalculate
 
-####Returns
+#### Returns
 
 Undo command object with the resulting change
 
-##`transformPoint`
+## `transformPoint`
 
 	var transformPoint = function( x, y, m )
 
 A (hopefully) quicker function to transform a point by a matrix (this function avoids any DOM calls and just does the math)
 
-####Parameters
+#### Parameters
 * `x` Float representing the x coordinate
 * `y` Float representing the y coordinate
 * `m` Matrix object to transform the point with Returns a x,y object representing the transformed point
 
-##`isIdentity`
+## `isIdentity`
 
 	var isIdentity = function( m )
 
 Helper function to check if the matrix performs no actual transform (i.e. exists for identity purposes)
 
-####Parameters
+#### Parameters
 
 * `m` The matrix object to check
 
-####Returns
+#### Returns
 
 Boolean indicating whether or not the matrix is `1,0,0,1,0,0`
 
-##`matrixMultiply`
+## `matrixMultiply`
 
 	var matrixMultiply = this.matrixMultiply = function()
 
 This function tries to return a SVGMatrix that is the multiplication `m1*m2`. We also round to zero when it’s near zero
 
-####Parameters
+#### Parameters
 
 `= 2 Matrix objects to multiply`
 
-####Returns
+#### Returns
 
 The matrix object resulting from the calculation
 
-##`transformListToTransform`
+## `transformListToTransform`
 
 	var transformListToTransform = this.transformListToTransform = function( tlist, min, max )
 This returns a single matrix Transform for a given Transform List (this is the equivalent of `SVGTransformList.consolidate()` but unlike that method, this one does not modify the actual `SVGTransformList`) This function is very liberal with its `min`, `max` arguments
 
-####Parameters
+#### Parameters
 
 * `tlist` The transformlist object
 * `min` Optional integer indicating start transform position
 * `max` Optional integer indicating end transform position
 
-####Returns
+#### Returns
 
 A single matrix transform object
 
-##`hasMatrixTransform`
+## `hasMatrixTransform`
 
 	var hasMatrixTransform = this.hasMatrixTransform = function( tlist )
 
 See if the given transformlist includes a non-indentity matrix transform
 
-####Parameters
+#### Parameters
 
 * `tlist` The transformlist to check
 
-####Returns
+#### Returns
 
 Boolean on whether or not a matrix transform was found
 
-##`getMatrix`
+## `getMatrix`
 
 	var getMatrix = function( elem )
 
 Get the matrix object for a given element
 
-####Parameters
+#### Parameters
 
 * `elem` The DOM element to check
 
-####Returns
+#### Returns
 
 The matrix object associated with the element’s transformlist
 
-##`transformBox`
+## `transformBox`
 
 	var transformBox = this.transformBox = function( l, t, w, h, m )
 
 Transforms a rectangle based on the given matrix
 
-####Parameters
+#### Parameters
 
 * `l` Float with the box’s left coordinate
 * `t` Float with the box’s top coordinate
@@ -1058,7 +1058,7 @@ Transforms a rectangle based on the given matrix
 * `h` Float with the box height
 * `m` Matrix object to transform the box by
 
-####Returns
+#### Returns
 
 An object with the following values:
 
@@ -1072,138 +1072,138 @@ An object with the following values:
 * Float with the axis-aligned width coordinate
 * Float with the axis-aligned height coordinate
 
-#Selection
+# Selection
 
-##`clearSelection`
+## `clearSelection`
 
 	var clearSelection = this.clearSelection = function( noCall )
 
 Clears the selection. The `selected` handler is then called.  Parameters: `noCall` - Optional boolean that when true does not call the “selected” handler
 
-##`addToSelection`
+## `addToSelection`
 
 	var addToSelection = this.addToSelection = function( elemsToAdd, showGrips )
 
 Adds a list of elements to the selection.  The ‘selected’ handler is then called.
 
-####Parameters
+#### Parameters
 
 * `elemsToAdd` an array of DOM elements to add to the selection
 * `showGrips` a boolean flag indicating whether the resize grips should be shown
 
-##`removeFromSelection`
+## `removeFromSelection`
 
 	var removeFromSelection = this.removeFromSelection = function( elemsToRemove )
 
 Removes elements from the selection.
 
-####Parameters
+#### Parameters
 
 * `elemsToRemove` an array of elements to remove from selection
 
-##`selectAllInCurrentLayer`
+## `selectAllInCurrentLayer`
 
 	this.selectAllInCurrentLayer = function()
 
 Clears the selection, then adds all elements in the current layer to the selection. This function then fires the selected event.
 
-##`smoothControlPoints`
+## `smoothControlPoints`
 
 	var smoothControlPoints = this.smoothControlPoints = function( ct1, ct2, pt )
 
 Takes three points and creates a smoother line based on them
 
-####Parameters
+#### Parameters
 
 * `ct1` Object with x and y values (first control point)
 * `ct2` Object with x and y values (second control point)
 * `pt` Object with x and y values (third point)
 
-####Returns
+#### Returns
 
 Array of two “smoothed” point objects
 
-##`getMouseTarget`
+## `getMouseTarget`
 
 	var getMouseTarget = this.getMouseTarget = function( evt )
 
 Gets the desired element from a mouse event
 
-####Parameters
+#### Parameters
 
 * `evt` Event object from the mouse event
 
-####Returns
+#### Returns
 
 DOM element we want
 
-##`preventClickDefault`
+## `preventClickDefault`
 
 	var preventClickDefault = function( img )
 
 Prevents default browser click behaviour on the given element
 
-####Parameters
+#### Parameters
 
 * `img` The DOM element to prevent the cilck on
 
-#Text edit functions
+# Text edit functions
 
 Functions relating to editing text elements
 
-#Path edit functions
+# Path edit functions
 
 Functions relating to editing path elements
 
-#Serialization
+# Serialization
 
-##`removeUnusedDefElems`
+## `removeUnusedDefElems`
 
 	var removeUnusedDefElems = this.removeUnusedDefElems = function()
 
 Looks at DOM elements inside the <defs> to see if they are referred to, removes them from the DOM if they are not.
 
-####Returns
+#### Returns
 
 The amount of elements that were removed
 
-##`svgCanvasToString`
+## `svgCanvasToString`
 
 	var svgCanvasToString = this.svgCanvasToString = function()
 
 Main function to set up the SVG content for output
 
-####Returns
+#### Returns
 
 String containing the SVG image for output
 
-##`svgToString`
+## `svgToString`
 
 	var svgToString = this.svgToString = function( elem, indent )
 
 Sub function ran on each SVG element to convert it to a string as desired
 
-####Parameters
+#### Parameters
 
 * `elem` The SVG element to convert
 * `indent` Integer with the amount of spaces to indent this tag
 
-####Returns
+#### Returns
 
 String with the given element as an SVG tag
 
-##`embedImage`
+## `embedImage`
 
 	this.embedImage = function( val, callback )
 
 Converts a given image file to a data URL when possible, then runs a given callback
 
-####Parameters
+#### Parameters
 
 * `val` String with the path/URL of the image
 * `callback` Optional function to run when image data is found, supplies the result (data URL or false) as first parameter.
 
-##`save`
+## `save`
 
 	this.save = function( opts )
 
@@ -1212,47 +1212,47 @@ Serializes the current drawing into SVG XML text and returns it to the ‘saved�
 #### Returns
 Nothing
 
-##`rasterExport`
+## `rasterExport`
 
 	this.rasterExport = function()
 
 Generates a PNG Data URL based on the current image, then calls “exported” with an object including the string and any issues found
 
-##`getSvgString`
+## `getSvgString`
 
 	this.getSvgString = function()
 
 Returns the current drawing as raw SVG XML text.
 
-####Returns
+#### Returns
 
 The current drawing as raw SVG XML text.
 
-##`setSvgString`
+## `setSvgString`
 
 	this.setSvgString = function( xmlString )
 
 This function sets the current drawing as the input SVG XML.
 
-####Parameters
+#### Parameters
 
 * `xmlString` The SVG as XML text.
 
-####Returns
+#### Returns
 
 This function returns false if the set was unsuccessful, true otherwise.
 
-##`importSvgString`
+## `importSvgString`
 
 	this.importSvgString = function( xmlString )
 
 This function imports the input SVG XML into the current layer in the drawing
 
-####Parameters
+#### Parameters
 
 * `xmlString` The SVG as XML text.
 
-####Returns
+#### Returns
 
 This function returns false if the import was unsuccessful, true otherwise.  
 
@@ -1263,164 +1263,164 @@ This function returns false if the import was unsuccessful, true otherwise.
 * import should happen in top-left of current zoomed viewport
 * create a new layer for the imported SVG
 
-#Layers
+# Layers
 
-##`identifyLayers`
+## `identifyLayers`
 
 	var identifyLayers = function()
 
 Updates layer system
 
-##`createLayer`
+## `createLayer`
 
 	this.createLayer = function( name )
 
 Creates a new top-level layer in the drawing with the given name, sets the current layer to it, and then clears the selection This function then calls the ‘changed’ handler.  This is an undoable action.
 
-####Parameters
+#### Parameters
 
 * `name` The given name
 
-##`deleteCurrentLayer`
+## `deleteCurrentLayer`
 
 	this.deleteCurrentLayer = function()
 
 Deletes the current layer from the drawing and then clears the selection. This function then calls the ‘changed’ handler. This is an undoable action.
 
-##`getNumLayers`
+## `getNumLayers`
 
 	this.getNumLayers = function()
 
 Returns the number of layers in the current drawing.
 
-####Returns
+#### Returns
 
 The number of layers in the current drawing.
 
-##`getLayer`
+## `getLayer`
 
 	this.getLayer = function( i )
 
 Returns the name of the ith layer.  If the index is out of range, an empty string is returned.
 
-####Parameters
+#### Parameters
 * `i` the zero-based index of the layer you are querying.
 
-####Returns
+#### Returns
 
 The name of the ith layer
 
-##`getCurrentLayer`
+## `getCurrentLayer`
 
 	this.getCurrentLayer = function()
 
 Returns the name of the currently selected layer.  If an error occurs, an empty string is returned.
 
-####Returns
+#### Returns
 
 The name of the currently active layer.
 
-##`setCurrentLayer`
+## `setCurrentLayer`
 
 	this.setCurrentLayer = function( name )
 
 Sets the current layer.  If the name is not a valid layer name, then this function returns false.  Otherwise it returns true.  This is not an undo-able action.
 
-####Parameters
+#### Parameters
 
 * `name` the name of the layer you want to switch to.
 
-####Returns
+#### Returns
 
 `true` if the current layer was switched, otherwise `false`
 
-##`renameCurrentLayer`
+## `renameCurrentLayer`
 
 	this.renameCurrentLayer = function( newname )
 
 Renames the current layer. If the layer name is not valid (i.e. unique), then this function does nothing and returns `false`, otherwise it returns `true`. This is an undo-able action.
 
-####Parameters
+#### Parameters
 
 * `newname` the new name you want to give the current layer. This name must be unique among all layer names.
 
-####Returns
+#### Returns
 
 `true` if the rename succeeded, `false` otherwise.
 
-##`setCurrentLayerPosition`
+## `setCurrentLayerPosition`
 
 	this.setCurrentLayerPosition = function( newpos )
 
 Changes the position of the current layer to the new value.  If the new index is not valid, this function does nothing and returns false, otherwise it returns true.  This is an undo-able action.
 
-####Parameters
+#### Parameters
 
 * `newpos` The zero-based index of the new position of the layer. This should be between
 `0` and (number of layers `1`)
 
-####Returns
+#### Returns
 
 `true` if the current layer position was changed, `false` otherwise.
 
-##`getLayerVisibility`
+## `getLayerVisibility`
 
 	this.getLayerVisibility = function(	 layername )
 
 Returns whether the layer is visible.  If the layer name is not valid, then this function returns false.
 
-####Parameters
+#### Parameters
 
 * `layername` the name of the layer which you want to query.
 
-####Returns
+#### Returns
 
 The visibility state of the layer, or false if the layer name was invalid.
 
-##`setLayerVisibility`
+## `setLayerVisibility`
 
 	this.setLayerVisibility = function( layername, bVisible )
 
 Sets the visibility of the layer.  If the layer name is not valid, this function return false, otherwise it returns true.  This is an undo-able action.
 
-####Parameters
+#### Parameters
 
 * `layername` the name of the layer to change the visibility
 * `bVisible` true/false, whether the layer should be visible
 
-####Returns
+#### Returns
 
 `true` if the layer’s visibility was set, `false` otherwise
 
-##`moveSelectedToLayer`
+## `moveSelectedToLayer`
 
 	this.moveSelectedToLayer = function( layername )
 
 Moves the selected elements to layername.  If the name is not a valid layer name, then false is returned.  Otherwise it returns true.  This is an undo-able action.
 
-####Parameters
+#### Parameters
 
 * `layername` the name of the layer you want to which you want to move the selected elements
 
-####Returns
+#### Returns
 
 `true` if the selected elements were moved to the layer, `false` otherwise.
 
-##`getLayerOpacity`
+## `getLayerOpacity`
 
 	this.getLayerOpacity = function( layername )
 
 Returns the opacity of the given layer.  If the input name is not a layer, null is returned.
 
-####Parameters
+#### Parameters
 
 * `layername` name of the layer on which to get the opacity
 
-####Returns
+#### Returns
 
 The opacity value of the given layer.  This will be a value between `0.0` and `1.0`, or null if layername is not a valid layer
 
-##`setLayerOpacity`
+## `setLayerOpacity`
 
 	this.setLayerOpacity = function( layername, opacity )
 
@@ -1428,560 +1428,560 @@ Sets the opacity of the given layer.  If the input name is not a layer, nothing 
 
 >NOTE: this function exists solely to apply a highlighting/de-emphasis effect to a layer, when it is possible for a user to affect the opacity of a layer, we will need to allow this function to produce an undo-able action.  If opacity is not a value between 0.0 and 1.0, then nothing happens.
 
-####Parameters
+#### Parameters
 
 * `layername` name of the layer on which to set the opacity
 * `opacity` a float value in the range 0.0-1.0
 
-#Document functions
+# Document functions
 
-##`clear`
+## `clear`
 
 	this.clear = function()
 
 Clears the current document.  This is not an undoable action.
 
-##`linkControlPoints`
+## `linkControlPoints`
 
 Alias function
 
-##`getContentElem`
+## `getContentElem`
 
 	this.getContentElem = function()
 
 Returns the content DOM element
 
-##`getRootElem`
+## `getRootElem`
 
 	this.getRootElem = function()
 
 Returns the root DOM element
 
-##`getSelectedElems`
+## `getSelectedElems`
 
 	this.getSelectedElems = function()
 
 Returns the array with selected DOM elements
 
-##`getResolution`
+## `getResolution`
 
 	var getResolution = this.getResolution = function()
 
 Returns the current dimensions and zoom level in an object
 
-##`getZoom`
+## `getZoom`
 
 	this.getZoom = function()
 
 Returns the current zoom level
 
-##`getVersion`
+## `getVersion`
 
 	this.getVersion = function()
 
 Returns a string which describes the revision number of SvgCanvas.
 
-##`setUiStrings`
+## `setUiStrings`
 
 	this.setUiStrings = function(strs)
 
 Update interface strings with given values
 
-####Parameters
+#### Parameters
 
 * `strs` Object with strings (see uiStrings for examples)
 
-##`setConfig`
+## `setConfig`
 
 	this.setConfig = function( opts )
 
 Update configuration options with given values
 
-####Parameters
+#### Parameters
 
 * `opts` Object with options (see curConfig for examples)
 
-##`getDocumentTitle`
+## `getDocumentTitle`
 
 	this.getDocumentTitle = function()
 
 Returns the current document title or an empty string if not found
 
-##`setDocumentTitle`
+## `setDocumentTitle`
 
 	this.setDocumentTitle = function( newtitle )
 
 Adds/updates a title element for the document with the given name.  This is an undoable action
 
-####Parameters
+#### Parameters
 
 * `newtitle` String with the new title
 
-##`getEditorNS`
+## `getEditorNS`
 
 	this.getEditorNS = function( add )
 
 Returns the editor’s namespace URL, optionally adds it to root element
 
-####Parameters
+#### Parameters
 
 * `add` Boolean to indicate whether or not to add the namespace value
 
-##`setResolution`
+## `setResolution`
 
 	this.setResolution = function( x, y )
 
 Changes the document’s dimensions to the given size
 
-####Parameters
+#### Parameters
 
 * `x` Number with the width of the new dimensions in user units.  Can also be the string “fit” to indicate “fit to content”
 * `y` Number with the height of the new dimensions in user units.
 
-####Returns
+#### Returns
 
 Boolean to indicate if resolution change was succesful.  It will fail on “fit to content” option with no content to fit to.
 
-##`getOffset`
+## `getOffset`
 
 	this.getOffset = function()
 
 Returns an object with `x`, `y` values indicating the svgcontent element’s position in the editor’s canvas.
 
-##`setBBoxZoom`
+## `setBBoxZoom`
 
 	this.setBBoxZoom = function( val, editor_w, editor_h )
 
 Sets the zoom level on the canvas-side based on the given value
 
-####Parameters
+#### Parameters
 
 * `val` Bounding box object to zoom to or string indicating zoom option
 * `editor_w` Integer with the editor’s workarea box’s width
 * `editor_h` Integer with the editor’s workarea box’s height
 
-##`setZoom`
+## `setZoom`
 
 	this.setZoom = function( zoomlevel )
 
 Sets the zoom to the given level
 
-####Parameters
+#### Parameters
 
 * `zoomlevel` Float indicating the zoom level to change to
 
-##`getMode`
+## `getMode`
 
 	this.getMode = function()
 
 Returns the current editor mode string
 
-##`setMode`
+## `setMode`
 
 	this.setMode = function( name )
 
 Sets the editor’s mode to the given string
 
-####Parameters
+#### Parameters
 
 * `name` String with the new mode to change to
 
-#Element Styling
+# Element Styling
 
-##`getColor`
+## `getColor`
 
 	this.getColor = function( type )
 
 Returns the current fill/stroke option
 
-##`setColor`
+## `setColor`
 
 	this.setColor = function( type, val, preventUndo )
 
 Change the current stroke/fill color/gradient value
 
-####Parameters
+#### Parameters
 
 * `type` String indicating fill or stroke
 * `val` The value to set the stroke attribute to
 * `preventUndo` Boolean indicating whether or not this should be and undoable option
 
-##`findDefs`
+## `findDefs`
 
 	var findDefs = function()
 
 Return the document’s `<defs>` element, create it first if necessary
 
-##`setGradient`
+## `setGradient`
 
 	var setGradient = this.setGradient = function( type )
 
 Apply the current gradient to selected element’s fill or stroke
 Parameters `type` - String indicating “fill” or “stroke” to apply to an element
 
-##`findDuplicateGradient`
+## `findDuplicateGradient`
 
 	var findDuplicateGradient = function( grad )
 
 Check if exact gradient already exists
 
-####Parameters
+#### Parameters
 
 * `grad` The gradient DOM element to compare to others
 
-####Returns
+#### Returns
 
 The existing gradient if found, null if not
 
-##`setPaint`
+## `setPaint`
 
 	this.setPaint = function( type, paint )
 
 Set a color/gradient to a fill/stroke
 
-####Parameters
+#### Parameters
 
 * `type` String with “fill” or “stroke”
 * `paint` The jGraduate paint object to apply
 
-##`getStrokeWidth`
+## `getStrokeWidth`
 
 	this.getStrokeWidth = function()
 
 Returns the current stroke-width value
 
-##`setStrokeWidth`
+## `setStrokeWidth`
 
 	this.setStrokeWidth = function( val )
 
 Sets the stroke width for the current selected elements When attempting to set a line’s width to 0, this changes it to 1 instead
 
-####Parameters
+#### Parameters
 
 * `val` A Float indicating the new stroke width value
 
-##`setStrokeAttr`
+## `setStrokeAttr`
 
 	this.setStrokeAttr = function( attr, val )
 
 Set the given stroke-related attribute the given value for selected elements
 
-####Parameters
+#### Parameters
 
 * `attr` String with the attribute name
 * `val` String or number with the attribute value
 
-##`getOpacity`
+## `getOpacity`
 
 	this.getOpacity = function()
 
 Returns the current opacity
 
-##`setOpacity`
+## `setOpacity`
 
 	this.setOpacity = function( val )
 
 Sets the given opacity to the current selected elements
 
-##`getOpacity`
+## `getOpacity`
 
 Returns the current fill opacity
 
-##`getStrokeOpacity`
+## `getStrokeOpacity`
 
 	this.getStrokeOpacity = function()
 
 Returns the current stroke opacity
 
-##`setPaintOpacity`
+## `setPaintOpacity`
 
 	this.setPaintOpacity = function( type, val, preventUndo )
 
 Sets the current fill/stroke opacity
 
-####Parameters
+#### Parameters
 
 * `type` String with “fill” or “stroke”
 * `val` Float with the new opacity value
 * `preventUndo` Boolean indicating whether or not this should be an undoable action
 
-##`getBlur`
+## `getBlur`
 
 	this.getBlur = function( elem )
 
 Gets the stdDeviation blur value of the given element
 
-####Parameters
+#### Parameters
 
 * `elem` The element to check the blur value for
 
-##`setBlurNoUndo`
+## `setBlurNoUndo`
 
 	canvas.setBlurNoUndo = function( val )
 
 Sets the stdDeviation blur value on the selected element without being undoable
 
-####Parameters
+#### Parameters
 
 * `val` The new stdDeviation value
 
-##`setBlurOffsets`
+## `setBlurOffsets`
 
 	canvas.setBlurOffsets = function( filter, stdDev )
 
 Sets the `x`, `y`, with, height values of the filter element in order to make the blur not be clipped.  Removes them if not neeeded
 
-####Parameters
+#### Parameters
 
 * `filter` The filter DOM element to update
 * `stdDev` The standard deviation value on which to base the offset size
 
-##`setBlur`
+## `setBlur`
 
 	canvas.setBlur = function( val, complete )
 
 Adds/updates the blur filter to the selected element
 
-####Parameters
+#### Parameters
 
 * `val` Float with the new stdDeviation blur value
 * `complete` Boolean indicating whether or not the action should be completed (to add to the undo manager)
 
-##`getBold`
+## `getBold`
 
 	this.getBold = function()
 
 Check whether selected element is bold or not
 
-####Returns
+#### Returns
 
 Boolean indicating whether or not element is bold
 
-##`setBold`
+## `setBold`
 
 	this.setBold = function( b )
 
 Make the selected element bold or normal
 
-####Parameters
+#### Parameters
 
 * `b` Boolean indicating bold `true` or normal `false`
 
-##`getItalic`
+## `getItalic`
 
 	this.getItalic = function()
 
 Check whether selected element is italic or not
 
-####Returns
+#### Returns
 
 Boolean indicating whether or not element is italic
 
-##`setItalic`
+## `setItalic`
 
 	this.setItalic = function( i )
 
 Make the selected element italic or normal
 
-####Parameters
+#### Parameters
 * `b` Boolean indicating italic (true) or normal (false)
 
-##`getFontFamily`
+## `getFontFamily`
 
 	this.getFontFamily = function()
 
 Returns the current font family
 
-##`setFontFamily`
+## `setFontFamily`
 
 	this.setFontFamily = function( val )
 
 Set the new font family
 
-####Parameters
+#### Parameters
 
 * `val` String with the new font family
 
-##`getFontSize`
+## `getFontSize`
 
 	this.getFontSize = function()
 
 Returns the current font size
 
-##`setFontSize`
+## `setFontSize`
 
 	this.setFontSize = function( val )
 
 Applies the given font size to the selected element
 
-####Parameters
+#### Parameters
 
 * `val` Float with the new font size
 
-##`getText`
+## `getText`
 
 	this.getText = function()
 
 Returns the current text `textContent` of the selected element
 
-##`setTextContent`
+## `setTextContent`
 
 	this.setTextContent = function( val )
 
 Updates the text element with the given string
 
-####Parameters
+#### Parameters
 
 * `val` String with the new text
 
-##`setImageURL`
+## `setImageURL`
 
 	this.setImageURL = function( val )
 
 Sets the new image URL for the selected image element.  Updates its size if a new URL is given
 
-####Parameters
+#### Parameters
 
 * `val` String with the image URL/path
 
-##`setRectRadius`
+## `setRectRadius`
 
 	this.setRectRadius = function( val )
 
 Sets the `rx` & `ry` values to the selected rect element to change its corner radius
 
-####Parameters
+#### Parameters
 
 * `val` The new radius
 
-#Element manipulation
+# Element manipulation
 
-##`setSegType`
+## `setSegType`
 
 	this.setSegType = function( new_type )
 
 Sets the new segment type to the selected segment(s).
 
-####Parameters
+#### Parameters
 
 * `new_type` Integer with the new segment type See http://www.w3.org/TR/SVG/paths.html#InterfaceSVGPathSeg for list
 
-##`convertToPath`
+## `convertToPath`
 
 	this.convertToPath = function( elem, getBBox )
 
 Convert selected element to a path, or get the BBox of an element-as-path
 
-####Parameters
+#### Parameters
 
 * `elem` The DOM element to be converted
 * `getBBox` Boolean on whether or not to only return the path’s BBox
 
-####Returns
+#### Returns
 
 If the getBBox flag is true, the resulting path’s bounding box object.  Otherwise the resulting path element is returned.
 
-##`changeSelectedAttributeNoUndo`
+## `changeSelectedAttributeNoUndo`
 
 	var changeSelectedAttributeNoUndo = function( attr, newValue, elems )
 
 This function makes the changes to the elements.  It does not add the change to the history stack.
 
-####Parameters
+#### Parameters
 
 * `attr` String with the attribute name
 * `newValue` String or number with the new attribute value
 * `elems` The DOM elements to apply the change to
 
-##`changeSelectedAttribute`
+## `changeSelectedAttribute`
 
 	var changeSelectedAttribute = this.changeSelectedAttribute = function( attr, val, elems )
 
 Change the given/selected element and add the original value to the history stack If you want to change all selectedElements, ignore the elems argument.  If you want to change only a subset of selectedElements, then send the subset to this function in the elems argument.
 
-####Parameters
+#### Parameters
 
 * `attr` String with the attribute name
 * `newValue` String or number with the new attribute value
 * `elems` The DOM elements to apply the change to
 
-##`deleteSelectedElements`
+## `deleteSelectedElements`
 
 	this.deleteSelectedElements = function()
 
 Removes all selected elements from the DOM and adds the change to the history stack
 
-##`groupSelectedElements`
+## `groupSelectedElements`
 
 	this.groupSelectedElements = function()
 
 Wraps all the selected elements in a group (g) element
 
-##`ungroupSelectedElement`
+## `ungroupSelectedElement`
 
 	this.ungroupSelectedElement = function()
 
 Unwraps all the elements in a selected group (g) element.  This requires significant recalculations to apply group’s transforms, etc to its children
 
-##`moveToTopSelectedElement`
+## `moveToTopSelectedElement`
 
 	this.moveToTopSelectedElement = function()
 
 Repositions the selected element to the bottom in the DOM to appear on top of other elements
 
-##`moveToBottomSelectedElement`
+## `moveToBottomSelectedElement`
 
 	this.moveToBottomSelectedElement = function()
 
 Repositions the selected element to the top in the DOM to appear under other elements
 
-##`moveSelectedElements`
+## `moveSelectedElements`
 
 	this.moveSelectedElements = function( dx, dy, undoable )
 
 Moves selected elements on the X/Y axis
 
-####Parameters
+#### Parameters
 
 * `dx` Float with the distance to move on the x-axis
 * `dy` Float with the distance to move on the y-axis
 * `undoable` Boolean indicating whether or not the action should be undoable
 
-####Returns
+#### Returns
 
 Batch command for the move
 
-##`cloneSelectedElements`
+## `cloneSelectedElements`
 
 	this.cloneSelectedElements = function()
 
 Create deep DOM copies (clones) of all selected elements and move them slightly from their originals
 
-##`alignSelectedElements`
+## `alignSelectedElements`
 
 	this.alignSelectedElements = function( type, relative_to )
 
 Aligns selected elements
 
-####Parameters
+#### Parameters
 
 * `type` String with single character indicating the alignment type
 * `relative_to` String that must be one of the following: “selected”, “largest”, “smallest”, “page”
 
-#Additional editor tools
+# Additional editor tools
 
-##`updateCanvas`
+## `updateCanvas`
 
 	this.updateCanvas = function( w, h )
 
 Updates the editor canvas width/height/position after a zoom has occurred
 
-####Parameters
+#### Parameters
 
 * `w` Float with the new width
 * `h` Float with the new height
 
-####Returns
+#### Returns
 
 Object with the following values:
 
@@ -1992,23 +1992,23 @@ Object with the following values:
 * `d_x` - The x position difference
 * `d_y` - The y position difference
 
-##`setBackground`
+## `setBackground`
 
 	this.setBackground = function( color, url )
 
 Set the background of the editor (NOT the actual document)
 
-####Parameters
+#### Parameters
 
 * `color` String with fill color to apply
 * `url` URL or path to image to use
 
-##`cycleElement`
+## `cycleElement`
 
 	this.cycleElement = function( next )
 
 Select the next/previous element within the current layer
 
-####Parameters
+#### Parameters
 
 * `next` Boolean where true = next and false = previous element


### PR DESCRIPTION
Github changed it's markdown parser, requiring a space between the hash and the text for headings.