### PR TITLE
Bug importing complex paths to svg edit

### DIFF
--- a/editor/svgutils.js
+++ b/editor/svgutils.js
@@ -1256,6 +1256,10 @@ svgedit.utilities.convertPath = function(path, toRel) {
 		switch (type) {
 			case 1: // z,Z closepath (Z/z)
 				d += 'z';
+				if (last_m && !toRel) {
+					curx = last_m[0];
+					cury = last_m[1];
+				}
 				break;
 			case 12: // absolute horizontal line (H)
 				x -= curx;
@@ -1292,12 +1296,6 @@ svgedit.utilities.convertPath = function(path, toRel) {
 				y -= cury;
 			case 5: // relative line (l)
 			case 3: // relative move (m)
-				// If the last segment was a "z", this must be relative to
-				if (last_m && segList.getItem(i-1).pathSegType === 1 && !toRel) {
-					curx = last_m[0];
-					cury = last_m[1];
-				}
-
 			case 19: // relative smooth quad (t)
 				if (toRel) {
 					curx += x;
@@ -1308,7 +1306,7 @@ svgedit.utilities.convertPath = function(path, toRel) {
 					curx = x;
 					cury = y;
 				}
-				if (type === 3) {last_m = [curx, cury];}
+				if (type === 2 || type === 3) {last_m = [curx, cury];}
 
 				d += pathDSegment(letter,[[x, y]]);
 				break;


### PR DESCRIPTION
Correct import of paths with several "M/m" and "Z/z"

After a "Z/z", the current position wasn't always correct.