### PR TITLE
Implemented a clipboard that works across tabs and windows.

### DIFF
--- a/editor/extensions/ext-connector.js
+++ b/editor/extensions/ext-connector.js
@@ -171,7 +171,8 @@ svgEditor.addExtension("Connector", function(S) {
 			// Grab the ends
 			var parts = [];
 			['start', 'end'].forEach(function (pos, i) {
-				var part = elData(this, 'c_'+pos);
+				var key = 'c_' + pos;
+				var part = elData(this, key);
 				if(part == null) {
 					part = document.getElementById(
 						this.attributes['se:connector'].value.split(' ')[i]

--- a/editor/extensions/ext-connector.js
+++ b/editor/extensions/ext-connector.js
@@ -598,6 +598,9 @@ svgEditor.addExtension("Connector", function(S) {
 				if('se:connector' in elem.attr) {
 					elem.attr['se:connector'] = elem.attr['se:connector'].split(' ')
 						.map(function(oldID){ return input.changes[oldID] }).join(' ');
+
+					// Check validity - the field would be something like 'svg_21 svg_22', but
+					// if one end is missing, it would be 'svg_21' and therefore fail this test
 					if(!/. ./.test(elem.attr['se:connector']))
 						remove.push(elem.attr.id);
 				}

--- a/editor/extensions/ext-connector.js
+++ b/editor/extensions/ext-connector.js
@@ -178,7 +178,7 @@ svgEditor.addExtension("Connector", function(S) {
 					);
 					elData(this, 'c_'+pos, part.id);
 					elData(this, pos+'_bb', svgCanvas.getStrokedBBox([part]));
-				}
+				} else part = document.getElementById(part);
 				parts.push(part);
 			}.bind(this));
 

--- a/editor/extensions/ext-connector.js
+++ b/editor/extensions/ext-connector.js
@@ -160,7 +160,6 @@ svgEditor.addExtension("Connector", function(S) {
 
 		// Loop through connectors to see if one is connected to the element
 		connectors.each(function() {
-			var connector = this;
 			var add_this;
 			function add () {
 				if ($.inArray(this, elems) !== -1) {
@@ -175,13 +174,13 @@ svgEditor.addExtension("Connector", function(S) {
 				var part = elData(this, 'c_'+pos);
 				if(part == null) {
 					part = document.getElementById(
-						connector.attributes['se:connector'].value.split(' ')[i]
+						this.attributes['se:connector'].value.split(' ')[i]
 					);
-					elData(connector, 'c_'+pos, part.id);
-					elData(connector, pos+'_bb', svgCanvas.getStrokedBBox([part]));
+					elData(this, 'c_'+pos, part.id);
+					elData(this, pos+'_bb', svgCanvas.getStrokedBBox([part]));
 				}
 				parts.push(part);
-			});
+			}.bind(this));
 
 			for (i = 0; i < 2; i++) {
 				var c_elem = parts[i];

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -4818,9 +4818,6 @@ TODOS
 							}
 							break;
 					}
-					if (svgCanvas.clipBoard.length) {
-						canv_menu.enableContextMenuItems('#paste,#paste_in_place');
-					}
 				}
 			);
 
@@ -4864,6 +4861,15 @@ TODOS
 
 			$('#cmenu_canvas li').disableContextMenu();
 			canv_menu.enableContextMenuItems('#delete,#cut,#copy');
+
+			canv_menu[(localStorage.getItem('svgedit_clipboard') ? 'en' : 'dis') + 'ableContextMenuItems']
+				('#paste,#paste_in_place');
+			window.addEventListener('storage', function(e) {
+				if(e.key != 'svgedit_clipboard') return;
+
+				canv_menu[(localStorage.getItem('svgedit_clipboard') ? 'en' : 'dis') + 'ableContextMenuItems']
+					('#paste,#paste_in_place');
+			});
 
 			window.addEventListener('beforeunload', function(e) {
 				// Suppress warning if page is empty

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -188,7 +188,7 @@ var getJsonFromSvgElement = this.getJsonFromSvgElement = function(data) {
         children: [],
     };
 
-    // Itrate attributes
+    // Iterate attributes
     for(var i=0; i < data.attributes.length; i++) {
         retval.attr[data.attributes[i].name] = data.attributes[i].value;
     };

--- a/editor/svgutils.js
+++ b/editor/svgutils.js
@@ -1191,8 +1191,9 @@ svgedit.utilities.copyElem = function(el, getNextId) {
 		var ref = $(el).data('symbol');
 		$(new_el).data('ref', ref).data('symbol', ref);
 	} else if (new_el.tagName == 'image') {
-		preventClickDefault(new_el);
+		svgedit.utilities.preventClickDefault(new_el);
 	}
+
 	return new_el;
 };
 


### PR DESCRIPTION
With this commit it's now possible to cut'n'paste svg elements across tabs and/or windows. It uses localStorage to achieve this.