### PR TITLE
Add ability to set the svg drawing without adding to the undo stack.

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -3817,7 +3817,7 @@ this.svgToString = function(elem, indent) {
 				var el = this;
 				// for some elements have no attribute
 				var uri = this.namespaceURI;
-				if(uri && !nsuris[uri] && nsMap[uri] && nsMap[uri] !== 'xmlns' && nsMap[uri] !== 'xml' ) {
+				if (uri && !nsuris[uri] && nsMap[uri] && nsMap[uri] !== 'xmlns' && nsMap[uri] !== 'xml' ) {
 					nsuris[uri] = true;
 					out.push(' xmlns:' + nsMap[uri] + '="' + uri +'"');
 				}
@@ -4596,7 +4596,7 @@ this.setSvgString = function(xmlString, preventUndo) {
 		svgedit.path.clearData();
 		svgroot.appendChild(selectorManager.selectorParentGroup);
 		
-		if(!preventUndo) addCommandToHistory(batchCmd);
+		if (!preventUndo) addCommandToHistory(batchCmd);
 		call('changed', [svgcontent]);
 	} catch(e) {
 		console.log(e);

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -4439,6 +4439,9 @@ var convertToGroup = this.convertToGroup = function(elem) {
 //
 // Parameters:
 // xmlString - The SVG as XML text.
+// preventUndo - Boolean (defaults to false) indicating if we want to do the
+// changes without adding them to the undo stack - e.g. for initializing a
+// drawing on page load.
 //
 // Returns:
 // This function returns false if the set was unsuccessful, true otherwise.

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -4442,7 +4442,7 @@ var convertToGroup = this.convertToGroup = function(elem) {
 //
 // Returns:
 // This function returns false if the set was unsuccessful, true otherwise.
-this.setSvgString = function(xmlString) {
+this.setSvgString = function(xmlString, preventUndo) {
 	try {
 		// convert string into XML document
 		var newDoc = svgedit.utilities.text2xml(xmlString);
@@ -4596,7 +4596,7 @@ this.setSvgString = function(xmlString) {
 		svgedit.path.clearData();
 		svgroot.appendChild(selectorManager.selectorParentGroup);
 		
-		addCommandToHistory(batchCmd);
+		if(!preventUndo) addCommandToHistory(batchCmd);
 		call('changed', [svgcontent]);
 	} catch(e) {
 		console.log(e);


### PR DESCRIPTION
When loading a file on init, it's useful to set it without it being added to the undo stack.