### PR TITLE
Bugfix/separate declaration from exposition

### DIFF
--- a/.jsdoc/configuration.json
+++ b/.jsdoc/configuration.json
@@ -4,8 +4,7 @@
     "exclude": [
       "node_modules",
       "dist"
-    ],
-    "excludePattern": "^svgedit-config-"
+    ]
   },
   "sourceType": "module",
   "tags": {

--- a/.jsdoc/configuration.json
+++ b/.jsdoc/configuration.json
@@ -4,7 +4,8 @@
     "exclude": [
       "node_modules",
       "dist"
-    ]
+    ],
+    "excludePattern": "^svgedit-config-"
   },
   "sourceType": "module",
   "tags": {

--- a/.jsdoc/configuration.json
+++ b/.jsdoc/configuration.json
@@ -17,6 +17,7 @@
   },
   "opts":{
     "recurse": true,
+    "verbose": true,
     "destination": ".jsdoc/out"
   }
 }

--- a/editor/embedapi.js
+++ b/editor/embedapi.js
@@ -95,7 +95,8 @@ function getMessageListener (t) {
 *   messages will be allowed when same origin is not used; defaults to none.
 *   If supplied, it should probably be the same as svgEditor's allowedOrigins
 */
-export default class EmbeddedSVGEdit {
+
+class EmbeddedSVGEdit {
   constructor (frame, allowedOrigins) {
     this.allowedOrigins = allowedOrigins || [];
     // Initialize communication
@@ -167,3 +168,5 @@ export default class EmbeddedSVGEdit {
     return cbid;
   }
 }
+
+export default EmbeddedSVGEdit;

--- a/editor/historyrecording.js
+++ b/editor/historyrecording.js
@@ -49,7 +49,7 @@ import {
  *     A value of null is valid for cases where no history recording is required.
  *     See singleton: HistoryRecordingService.NO_HISTORY
  */
-export default class HistoryRecordingService {
+class HistoryRecordingService {
   constructor (undoManager) {
     this.undoManager_ = undoManager;
     this.currentBatchCommand_ = null;
@@ -158,3 +158,4 @@ export default class HistoryRecordingService {
  * @property {HistoryRecordingService} NO_HISTORY - Singleton that can be passed to functions that record history, but the caller requires that no history be recorded.
  */
 HistoryRecordingService.NO_HISTORY = new HistoryRecordingService();
+export default HistoryRecordingService;

--- a/editor/jgraduate/jpicker.js
+++ b/editor/jgraduate/jpicker.js
@@ -19,7 +19,7 @@ Math.precision = function (value, precision) {
   return Math.round(value * Math.pow(10, precision)) / Math.pow(10, precision);
 };
 
-export default function ($) {
+const jPicker = function ($) {
   if (!$.loadingStylesheets) {
     $.loadingStylesheets = [];
   }
@@ -1885,3 +1885,5 @@ export default function ($) {
   };
   return $;
 }
+
+export default jPicker;

--- a/editor/layer.js
+++ b/editor/layer.js
@@ -28,7 +28,7 @@ const $ = jQuery;
  * @param {SVGGElement=} svgElem - The SVG DOM element. If defined, use this to add
  *     a new layer to the document.
  */
-export default class Layer {
+class Layer {
   constructor (name, group, svgElem) {
     this.name_ = name;
     this.group_ = svgElem ? null : group;
@@ -208,3 +208,5 @@ function addLayerClass (elem) {
     elem.setAttribute('class', classes + ' ' + Layer.CLASS_NAME);
   }
 }
+
+export default Layer;

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -84,7 +84,7 @@ if (window.opera) {
 * @param container - The container HTML element that should hold the SVG root element
 * @param {Object} config - An object that contains configuration data
 */
-export default class {
+class SvgCanvas {
   constructor (container, config) {
 // Alias Namespace constants
 
@@ -6111,3 +6111,5 @@ this.getPrivateMethods = function () {
 };
   } // End constructor
 } // End class
+
+export default SvgCanvas;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "engines": {},
   "scripts": {
     "build-config": "rollup -c rollup-config.config.js",
-    "build-doc": "jsdoc -c .jsdoc/configuration.json .",
+    "build-doc": "rm -rf .jsdoc/out/*;jsdoc -c .jsdoc/configuration.json .",
     "build-html": "node build-html.js",
     "compress-images": "imageoptim 'chrome-app/*.png' && imageoptim 'editor/extensions/*.png' && imageoptim 'editor/spinbtn/*.png' && imageoptim 'editor/jgraduate/images/*.{png,gif}' && imageoptim 'editor/images/*.png'",
     "copy-deps": "cp node_modules/load-stylesheets/dist/index-es.js editor/external/load-stylesheets/index-es.js && cp node_modules/babel-polyfill/dist/polyfill.min.js editor/external/babel-polyfill/polyfill.min.js && cp node_modules/babel-polyfill/dist/polyfill.js editor/external/babel-polyfill/polyfill.js",


### PR DESCRIPTION
This PR separate declaration of js item and their exposition. It fixes issue with jsDoc when both are mixed.

This PR follow the discussion we had with @brettz9 on [jsdoc PR](https://github.com/SVG-Edit/svgedit/pull/244)

Moreover, I increase versosity of the tasks and suppress previously generated documentation before generating new one.