### PR TITLE
Sort SVG attributes alphabetically.

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -2969,7 +2969,7 @@ this.svgToString = function (elem, indent) {
   if (elem) {
     cleanupElement(elem);
     const attrs = Array.from(elem.attributes);
-    let attr, i;
+    let i;
     const childs = elem.childNodes;
     attrs.sort((a, b) => a.name > b.name ? -1 : 1);
 
@@ -3023,7 +3023,7 @@ this.svgToString = function (elem, indent) {
       i = attrs.length;
       const attrNames = ['width', 'height', 'xmlns', 'x', 'y', 'viewBox', 'id', 'overflow'];
       while (i--) {
-        attr = attrs[i];
+        let attr = attrs[i];
         const attrVal = toXml(attr.value);
 
         // Namespaces have already been dealt with, so skip
@@ -3044,7 +3044,7 @@ this.svgToString = function (elem, indent) {
 
       const mozAttrs = ['-moz-math-font-style', '_moz-math-font-style'];
       for (i = attrs.length - 1; i >= 0; i--) {
-        attr = attrs[i];
+        let attr = attrs[i];
         let attrVal = toXml(attr.value);
         // remove bogus attributes added by Gecko
         if (mozAttrs.includes(attr.localName)) { continue; }

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -2968,9 +2968,10 @@ this.svgToString = function (elem, indent) {
 
   if (elem) {
     cleanupElement(elem);
-    const attrs = elem.attributes;
+    const attrs = Array.from(elem.attributes);
     let attr, i;
     const childs = elem.childNodes;
+    attrs.sort((a, b) => a.name > b.name ? -1 : 1);
 
     for (i = 0; i < indent; i++) { out.push(' '); }
     out.push('<'); out.push(elem.nodeName);
@@ -3022,7 +3023,7 @@ this.svgToString = function (elem, indent) {
       i = attrs.length;
       const attrNames = ['width', 'height', 'xmlns', 'x', 'y', 'viewBox', 'id', 'overflow'];
       while (i--) {
-        attr = attrs.item(i);
+        attr = attrs[i];
         const attrVal = toXml(attr.value);
 
         // Namespaces have already been dealt with, so skip
@@ -3043,7 +3044,7 @@ this.svgToString = function (elem, indent) {
 
       const mozAttrs = ['-moz-math-font-style', '_moz-math-font-style'];
       for (i = attrs.length - 1; i >= 0; i--) {
-        attr = attrs.item(i);
+        attr = attrs[i];
         let attrVal = toXml(attr.value);
         // remove bogus attributes added by Gecko
         if (mozAttrs.includes(attr.localName)) { continue; }


### PR DESCRIPTION
This makes the exported SVG deterministic and diffable.

Previous output:
```
  <ellipse id="svg_1" ry="92" rx="106" cy="127.5" cx="85.5" stroke-width="5" stroke="#000000" fill="#FF0000"/>
  <ellipse stroke="#000000" id="svg_2" ry="71" rx="101.5" cy="219.5" cx="255" stroke-width="5" fill="#FF0000"/>
```
New output:
```
  <ellipse cx="205.5" cy="170.5" fill="#FF0000" id="svg_1" rx="42" ry="38" stroke="#000000" stroke-width="5"/>
  <ellipse cx="312.5" cy="245.5" fill="#FF0000" id="svg_2" rx="96" ry="88" stroke="#000000" stroke-width="5"/>
```