### PR TITLE
Stop throwing traceback if there's no context menu

### DIFF
--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -6358,8 +6358,10 @@ this.copySelectedElements = function () {
   localStorage.setItem('svgedit_clipboard', JSON.stringify(
     selectedElements.map(function (x) { return getJsonFromSvgElement(x); })
   ));
-
-  $('#cmenu_canvas').enableContextMenuItems('#paste,#paste_in_place');
+  let menu = $('#cmenu_canvas');
+  if (menu) {
+    menu.enableContextMenuItems('#paste,#paste_in_place');
+  }
 };
 
 /**


### PR DESCRIPTION
SvgCanvas is currently inappropriately assuming that a context menu exists.  If it doesn't (as in the case where SvgCanvas is being used without editor.js), an error is thrown whenever content is pasted.