### PR TITLE
Enhancement: #381 Set base units preference from input svg file header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ mochawesome-report
 mochawesome.json
 
 .vscode
+/.idea/

--- a/editor/svg-editor.js
+++ b/editor/svg-editor.js
@@ -333,9 +333,10 @@ let svgCanvas, urldata = {},
  *   loading fails and `noAlert` is truthy.
  */
 async function loadSvgString (str, {noAlert} = {}) {
-  const success = svgCanvas.setSvgString(str) !== false;
+  const result = svgCanvas.setSvgString(str);
+  const success = result !== false;
   if (success) {
-    return;
+    return result;
   }
 
   if (!noAlert) {
@@ -6260,7 +6261,12 @@ editor.init = function () {
         $.process_cancel(uiStrings.notification.loadingImage);
         const reader = new FileReader();
         reader.onloadend = async function ({target}) {
-          await loadSvgString(target.result);
+          const result = await loadSvgString(target.result);
+          if (result && result.baseUnit) {
+            curConfig.baseUnit = result.baseUnit;
+            $('#base_unit').val(curConfig.baseUnit);
+            svgCanvas.setConfig(curConfig);
+          }
           updateCanvas();
         };
         reader.readAsText(this.files[0]);

--- a/editor/units.js
+++ b/editor/units.js
@@ -250,26 +250,36 @@ export const convertAttrs = function (element) {
 * @returns {Float} The converted number
 */
 export const convertToNum = function (attr, val) {
+  return parseLengthValue(attr, val).inPx;
+};
+
+export const parseLengthValue = function (attr, val) {
   // Return a number if that's what it already is
-  if (!isNaN(val)) { return val - 0; }
+  if (!isNaN(val)) {
+    const num = val - 0;
+    return {amount: num, unit: 'px', inPx: num};
+  }
   if (val.substr(-1) === '%') {
     // Deal with percentage, depends on attribute
+    const unit = '%';
     const num = val.substr(0, val.length - 1) / 100;
     const width = elementContainer_.getWidth();
     const height = elementContainer_.getHeight();
 
     if (wAttrs.includes(attr)) {
-      return num * width;
+      return {amount: num, unit: unit, inPx: num * width};
     }
     if (hAttrs.includes(attr)) {
-      return num * height;
+      return {amount: num, unit: unit, inPx: num * height};
     }
-    return num * Math.sqrt((width * width) + (height * height)) / Math.sqrt(2);
+    const inPx = num * Math.sqrt((width * width) + (height * height)) / Math.sqrt(2);
+    return {amount: num, unit: unit, inPx: inPx};
   }
   const unit = val.substr(-2);
   const num = val.substr(0, val.length - 2);
   // Note that this multiplication turns the string into a number
-  return num * typeMap_[unit];
+  const inPx = num * typeMap_[unit];
+  return {amount: num, unit: unit, inPx: inPx};
 };
 
 /**


### PR DESCRIPTION
I took few pretty daring decisions in order to achieve the desired result, any improvement suggestions are very welcome.

The thing that will most likely arise your concern is that I changed return value of `svgCanvas.setSvgString()` from `true/false` to `Object/false`, where object holds the parsed SVG values that should be passed to the editor.