### PR TITLE
Fix: update rollup.config.js. #401

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,7 +4,7 @@
 // See rollup-config.config.js instead for building the main (configurable)
 //   user entrance file
 import {join, basename} from 'path';
-import {lstatSync, readdirSync, copyFileSync} from 'fs';
+import {lstatSync, readdirSync, copyFileSync, mkdirSync} from 'fs';
 
 import babel from 'rollup-plugin-babel';
 import {terser} from 'rollup-plugin-terser';
@@ -183,6 +183,9 @@ export default [
   }),
   ...extensionFiles.map((extensionFile) => {
     if (extensionFile.match(/\.php$/)) {
+      mkdirSync('dist/extensions', { recursive: true }, (err) => {
+        if (err) throw err;
+      });
       copyFileSync(
         join('editor/extensions', extensionFile),
         join('dist/extensions', extensionFile)

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -183,9 +183,7 @@ export default [
   }),
   ...extensionFiles.map((extensionFile) => {
     if (extensionFile.match(/\.php$/)) {
-      mkdirSync('dist/extensions', { recursive: true }, (err) => {
-        if (err) throw err;
-      });
+      mkdirSync('dist/extensions', {recursive: true});
       copyFileSync(
         join('editor/extensions', extensionFile),
         join('dist/extensions', extensionFile)


### PR DESCRIPTION
This fixes #401: it creates the dist/extensions folder if it does not exist yet