### PR TITLE
fix issue with undo because this.elem was overwritten with node.remove()

### DIFF
--- a/cypress/integration/ui/issues/issue-359.js
+++ b/cypress/integration/ui/issues/issue-359.js
@@ -1,0 +1,26 @@
+import {
+  visitAndApproveStorage
+} from '../../../support/ui-test-helper.js';
+
+// See https://github.com/SVG-Edit/svgedit/issues/359
+describe('Fix issue 359', function () {
+  beforeEach(() => {
+    visitAndApproveStorage();
+  });
+
+  it('can undo without throwing', function () {
+    cy.get('#tool_source').click();
+    cy.get('#svg_source_textarea')
+      .type('{selectall}')
+      .type(`<svg width="640" height="480" xmlns="http://www.w3.org/2000/svg">
+      <g class="layer">
+       <title>Layer 1</title>
+        <rect fill="#ffff00" height="70" width="165" x="179.5" y="146.5"/>
+      </g>
+     </svg>`, {parseSpecialCharSequences: false});
+    cy.get('#tool_source_save').click();
+    cy.get('#tool_undo').click();
+    cy.get('#tool_redo').click(); // test also redo to make the test more comprehensive
+    // if the undo throws an error to the console, the test will fail
+  });
+});

--- a/editor/extensions/ext-connector.js
+++ b/editor/extensions/ext-connector.js
@@ -573,18 +573,19 @@ export default {
       },
       elementChanged (opts) {
         let elem = opts.elems[0];
-        if (elem && elem.tagName === 'svg' && elem.id === 'svgcontent') {
+        if (!elem) return;
+        if (elem.tagName === 'svg' && elem.id === 'svgcontent') {
           // Update svgcontent (can change on import)
           svgcontent = elem;
           init();
         }
 
         // Has marker, so change offset
-        if (elem && (
+        if (
           elem.getAttribute('marker-start') ||
           elem.getAttribute('marker-mid') ||
           elem.getAttribute('marker-end')
-        )) {
+        ) {
           const start = elem.getAttribute('marker-start');
           const mid = elem.getAttribute('marker-mid');
           const end = elem.getAttribute('marker-end');

--- a/editor/history.js
+++ b/editor/history.js
@@ -223,7 +223,7 @@ export class InsertElementCommand extends Command {
     }
 
     this.parent = this.elem.parentNode;
-    this.elem = this.elem.remove();
+    this.elem.remove();
 
     if (handler) {
       handler.handleHistoryEvent(HistoryEventTypes.AFTER_UNAPPLY, this);
@@ -280,7 +280,7 @@ export class RemoveElementCommand extends Command {
 
     removeElementFromListMap(this.elem);
     this.parent = this.elem.parentNode;
-    this.elem = this.elem.remove();
+    this.elem.remove();
 
     if (handler) {
       handler.handleHistoryEvent(HistoryEventTypes.AFTER_APPLY, this);

--- a/editor/svgcanvas.js
+++ b/editor/svgcanvas.js
@@ -516,7 +516,7 @@ const undoMgr = canvas.undoMgr = new UndoManager({
         } else if (!isApply) {
           restoreRefElems(cmd.elem);
         }
-        if (cmd.elem.tagName === 'use') {
+        if (cmd.elem && cmd.elem.tagName === 'use') {
           setUseData(cmd.elem);
         }
       } else if (cmdType === ChangeElementCommand.type()) {


### PR DESCRIPTION
## PR description

The issue is described there: issue #359 

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [X] - Added Cypress UI tests
- [C] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
