### PR TITLE
#570 The space above and under the color picker are not consistent

### DIFF
--- a/src/editor/components/sePalette.js
+++ b/src/editor/components/sePalette.js
@@ -24,7 +24,6 @@ template.innerHTML = `
   }
   #palette_holder {
     overflow: hidden;
-    margin-top: 5px;
     padding: 5px;
     position: absolute;
     right: 15px;


### PR DESCRIPTION
## PR description

The space above and under the color picker are not consistent

![SVG-edit (4)](https://user-images.githubusercontent.com/44435283/120800574-bbe66100-c55d-11eb-8c40-b435bbb05bc6.png)

