### PR TITLE
#386 Polyline/path canceled by a right-click crashes the app state

### DIFF
--- a/src/svgcanvas/event.js
+++ b/src/svgcanvas/event.js
@@ -966,6 +966,9 @@ export const mouseDownEvent = function (evt) {
   evt.preventDefault();
 
   if (rightClick) {
+    if(eventContext_.getCurrentMode() === 'path'){
+      return;
+    }
     eventContext_.setCurrentMode('select');
     eventContext_.setLastClickPoint(pt);
   }


### PR DESCRIPTION
## PR description

Polyline/path canceled by a right-click crashes the app state