### PR TITLE
#637 control points and handles only display correctly the first time

### DIFF
--- a/src/svgcanvas/path-actions.js
+++ b/src/svgcanvas/path-actions.js
@@ -861,7 +861,7 @@ export const pathActionsMethod = (function () {
         const pathpointgripContainer = getElem('pathpointgrip_container');
         const elements = pathpointgripContainer.querySelectorAll('*');
         Array.prototype.forEach.call(elements, function(el){
-          el.style.display = 'none';
+          el.setAttribute('display', 'none');
         });
         firstCtrl = null;
         editorContext_.setDrawnPath(null);

--- a/src/svgcanvas/path-method.js
+++ b/src/svgcanvas/path-method.js
@@ -640,7 +640,7 @@ export class Path {
     const pointGripContainer = getGripContainerMethod();
     const elements = pointGripContainer.querySelectorAll('*');
     Array.prototype.forEach.call(elements, function(el){
-      el.style.display = 'none';
+      el.setAttribute('display', 'none');
     });
 
     const segList = this.elem.pathSegList;


### PR DESCRIPTION
Tested with basic shapes converted to path and with normal path object. Prior to this fix, control points and handles would only display correctly the first time.