### PR TITLE
#639 path #1 draws its control point handles connected to path #2

### DIFF
--- a/src/svgcanvas/path-actions.js
+++ b/src/svgcanvas/path-actions.js
@@ -757,6 +757,7 @@ export const pathActionsMethod = (function () {
       path = pathActionsContext_.getPath_(element);
       editorContext_.setCurrentMode('pathedit');
       editorContext_.clearSelection();
+      path.setPathContext();
       path.show(true).update();
       path.oldbbox = utilsGetBBox(path.elem);
       subpath = false;
@@ -770,6 +771,7 @@ export const pathActionsMethod = (function () {
       editorContext_ = pathActionsContext_.getEditorContext();
       const selPath = (elem === path.elem);
       editorContext_.setCurrentMode('select');
+      path.setPathContext();
       path.show(false);
       currentPath = false;
       editorContext_.clearSelection();

--- a/src/svgcanvas/path-method.js
+++ b/src/svgcanvas/path-method.js
@@ -629,6 +629,10 @@ export class Path {
     this.init();
   }
 
+  setPathContext() {
+    pathMethodsContext_.setPathObj(this);
+  }
+
   /**
   * Reset path data.
   * @returns {module:path.Path}


### PR DESCRIPTION
Fixes  https://github.com/SVG-Edit/svgedit/issues/639

pathMethodsContext_.setPathObj(this) was only being called on path instantiation. So if you edit path1, then path2 and then switch back to path1 and go into edit mode, the context is pointing at the last path you edited (path2) and the control handles for path1 are drawn connected to path2.
