### PR TITLE
Renforcement : add text edition button in canvas demo without editor

### DIFF
--- a/demos/canvas.html
+++ b/demos/canvas.html
@@ -16,13 +16,15 @@
     <div>
       [<button onclick="canvas.setMode('select')">Select</button>
       <button onclick="canvas.setMode('circle')">Circle</button>
-      <button onclick="canvas.setMode('rect')">Rect</button>]
+      <button onclick="canvas.setMode('rect')">Rect</button>
+      <button onclick="canvas.setMode('text')">Text</button>]
       <button onclick="fill('#ff0000')">Fill Red</button>
       <button onclick="canvas.deleteSelectedElements()">Delete Selected</button>
       <button onclick="canvas.clear(); canvas.updateCanvas(width, height);">Clear All</button>
       <button onclick="alert(canvas.getSvgString())">Get SVG</button>
     </div>
-
+    <!-- Not visible, but useful -->
+    <input id="text" style="width:0;height:0;opacity: 0"/>
     <script type="module">
 /* globals canvas */
 import SvgCanvas from '../src/svgcanvas/svgcanvas.js';
@@ -31,6 +33,8 @@ const container = document.querySelector('#editorContainer');
 const { width, height } = { width: 500, height: 300 };
 window.width = width;
 window.height = height;
+
+const hiddenTextTagId = "text";
 
 const config = {
   initFill: { color: 'FFFFFF', opacity: 1 },
@@ -50,6 +54,18 @@ window.fill = function (colour) {
     el.setAttribute('fill', colour);
   });
 };
+
+let hiddenTextTag = window.canvas.$id(hiddenTextTagId);
+window.canvas.textActions.setInputElem(hiddenTextTag);
+
+const addListenerMulti = (element, eventNames, listener)=> {
+  eventNames.split(' ').forEach((eventName)=> element.addEventListener(eventName, listener, false));
+};
+
+addListenerMulti(hiddenTextTag, 'keyup input', (evt) => {
+  window.canvas.setTextContent(evt.currentTarget.value);
+});
+
     </script>
   </body>
 </html>

--- a/demos/canvas.html
+++ b/demos/canvas.html
@@ -55,7 +55,7 @@ window.fill = function (colour) {
   });
 };
 
-let hiddenTextTag = window.canvas.$id(hiddenTextTagId);
+const hiddenTextTag = window.canvas.$id(hiddenTextTagId);
 window.canvas.textActions.setInputElem(hiddenTextTag);
 
 const addListenerMulti = (element, eventNames, listener)=> {


### PR DESCRIPTION
## PR description

Add a button to edit text in the canvas demo without editor


## Checklist

- [ - ] - Added Cypress UI tests
- [ X ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ - ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
