### PR TITLE
Fix : call selectedChanged notification with empty selected elems arr…

### DIFF
--- a/src/svgcanvas/selection.js
+++ b/src/svgcanvas/selection.js
@@ -51,7 +51,7 @@ export const clearSelectionMethod = function (noCall) {
   svgCanvas.setEmptySelectedElements();
 
   if (!noCall) {
-    svgCanvas.call("selected", selectedElements);
+    svgCanvas.call("selected", selectionContext_.getSelectedElements());
   }
 };
 


### PR DESCRIPTION
## PR description

when clearSelectionMethod is called, the selectedChanged is called but the elems is not empty.
The PR correct this problem.

## Checklist

- [ - ] - Added Cypress UI tests
- [  x ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ - ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
