### PR TITLE
[issue-674] Bypass the ns with the attribute for the se attributes in…

### DIFF
--- a/src/svgcanvas/sanitize.js
+++ b/src/svgcanvas/sanitize.js
@@ -166,7 +166,9 @@ export const sanitizeSvg = function (node) {
         // We can add specific namepaces on demand for now.
         // Is there a more appropriate way to do this?
         if (attrName.startsWith('se:') || attrName.startsWith('oi:')|| attrName.startsWith('data-')) {
-          seAttrs.push([ attrName, attr.value ]);
+          // We should bypass the namespace aswell
+          const seAttrNS = (attrName.startsWith('se:')) ? NS.SE : ((attrName.startsWith('oi:')) ? NS.OI : null);
+          seAttrs.push([ attrName, attr.value, seAttrNS ]);
         } else {
           console.warn(`sanitizeSvg: attribute ${attrName} in element ${node.nodeName} not in whitelist is removed`);
           node.removeAttributeNS(attrNsURI, attrLocalName);
@@ -190,8 +192,8 @@ export const sanitizeSvg = function (node) {
       }
     }
 
-    Object.values(seAttrs).forEach(([ att, val ]) => {
-      node.setAttributeNS(NS.SE, att, val);
+    Object.values(seAttrs).forEach(([ att, val, ns ]) => {
+      node.setAttributeNS(ns, att, val);
     });
 
     // for some elements that have a xlink:href, ensure the URI refers to a local element


### PR DESCRIPTION
… orther to avoid attribute duplication

## PR description

PR for fixing issue 674. Resolved bypassing the attribute namespace on the se attributes bypass. This resolve the data-name attribute duplication.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
