### PR TITLE
Fix undo on converting rectangle to path creating an exception

### DIFF
--- a/cypress/integration/ui/issues/issue-699.js
+++ b/cypress/integration/ui/issues/issue-699.js
@@ -1,0 +1,29 @@
+import {
+  visitAndApproveStorage
+} from '../../../support/ui-test-helper.js'
+
+// See https://github.com/SVG-Edit/svgedit/issues/699
+describe('Fix issue 699', function () {
+  beforeEach(() => {
+    visitAndApproveStorage()
+  })
+
+  it('should not throw error when undoing and redoing convert to path for a rectangle', function () {
+    cy.get('#tool_rect')
+      .click({ force: true })
+    cy.get('#svgcontent')
+      .trigger('mousedown', 150, 150, { force: true })
+      .trigger('mousemove', 250, 200, { force: true })
+      .trigger('mouseup', { force: true })
+    cy.get('#tool_topath') // Check if undo redo is correct for tool_topath with tool_rect
+      .click({ force: true })
+    cy.get('#tool_undo')
+      .click({ force: true })
+    cy.get('#tool_redo')
+      .click({ force: true })
+    cy.get('#tool_undo') // Do twice just to make sure
+      .click({ force: true })
+    cy.get('#tool_redo')
+      .click({ force: true })
+  })
+})

--- a/src/svgcanvas/utilities.js
+++ b/src/svgcanvas/utilities.js
@@ -760,11 +760,11 @@ export const convertToPath = (elem, attrs, svgCanvas) => {
     }
 
     const { nextSibling } = elem
-    batchCmd.addSubCommand(new svgCanvas.history.RemoveElementCommand(elem, nextSibling, parent))
-    batchCmd.addSubCommand(new svgCanvas.history.InsertElementCommand(path))
-
+    batchCmd.addSubCommand(new svgCanvas.history.RemoveElementCommand(elem, nextSibling, elem.parentNode))
     svgCanvas.clearSelection()
     elem.remove()
+    
+    batchCmd.addSubCommand(new svgCanvas.history.InsertElementCommand(path))
     path.setAttribute('id', id)
     path.removeAttribute('visibility')
     svgCanvas.addToSelection([path], true)

--- a/src/svgcanvas/utilities.js
+++ b/src/svgcanvas/utilities.js
@@ -763,7 +763,7 @@ export const convertToPath = (elem, attrs, svgCanvas) => {
     batchCmd.addSubCommand(new svgCanvas.history.RemoveElementCommand(elem, nextSibling, elem.parentNode))
     svgCanvas.clearSelection()
     elem.remove()
-    
+
     batchCmd.addSubCommand(new svgCanvas.history.InsertElementCommand(path))
     path.setAttribute('id', id)
     path.removeAttribute('visibility')


### PR DESCRIPTION
## PR description
 
 This is a bugfix for the issue mentioned at https://github.com/SVG-Edit/svgedit/issues/699


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#699: Undoing a convert to Path on a rectangle creates an exception](https://issuehunt.io/repos/21611548/issues/699)
---
</details>
<!-- /Issuehunt content-->