### PR TITLE
fix: selector frame follows zoom properly

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -611,6 +611,9 @@ class Editor extends EditorStartup {
    * @returns {void}
    */
   zoomDone () {
+    for (const el of this.svgCanvas.selectedElements) {
+      this.svgCanvas.selectorManager.requestSelector(el).resize()
+    }
     this.updateWireFrame()
   }
 


### PR DESCRIPTION
## PR description

Selectors around objects weren't following zoom, so I added proper refresh to make them follow canvas zoom.
