### PR TITLE
Check if config item is an array

### DIFF
--- a/src/editor/ConfigObj.js
+++ b/src/editor/ConfigObj.js
@@ -393,7 +393,7 @@ export default class ConfigObj {
      * @returns {void}
      */
     const extendOrAdd = (cfgObj, key, val) => {
-      if (cfgObj[key] && typeof cfgObj[key] === 'object') {
+      if (cfgObj[key] && typeof cfgObj[key] === 'object' && !Array.isArray(cfgObj[key])) {
         cfgObj[key] = mergeDeep(cfgObj[key], val)
       } else {
         cfgObj[key] = val


### PR DESCRIPTION
## PR description

Fix: don't merge config item if it's an array. 
Bumped into this issue when trying to configure `dimensions`.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
