### PR TITLE
Disable pointer events on inactive context menu items

### DIFF
--- a/src/editor/dialogs/cmenuDialog.html
+++ b/src/editor/dialogs/cmenuDialog.html
@@ -50,6 +50,7 @@
 
     .contextMenu li.disabled a {
         color: #999;
+        pointer-events: none;
     }
 
     .contextMenu li.hover.disabled a {

--- a/src/editor/dialogs/cmenuLayersDialog.html
+++ b/src/editor/dialogs/cmenuLayersDialog.html
@@ -50,6 +50,7 @@
 
     .contextMenu li.disabled a {
         color: #999;
+        pointer-events: none;
     }
 
     .contextMenu li.hover.disabled a {


### PR DESCRIPTION
## PR description

This small PR adds CSS "pointer-events: none;" to disabled items in context menu.
The reason is that currently some inactive items are still clickable and trigger actions when clicked (e.g. group, even when executed on empty canvas)

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
