### PR TITLE
Enable text tool panel wen multiple text elements are selected.

### DIFF
--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -422,20 +422,10 @@ class TopPanel {
 
       // if (elem)
     } else if (this.multiselected) {
-      // Check if all selected elements have the same tag
+      // Check if all selected elements are 'text' nodes, if yes enable text panel
       const selElems = this.editor.svgCanvas.getSelectedElements()
-      const tagNames = []
-      selElems.forEach(elem => {
-        const { tagName } = elem
-        tagNames.push(tagName)
-      })
-      const allElemsSameTag = tagNames.every((val, i, arr) => val === arr[0])
-
-      // Enable panels specific for selected elements
-      if (allElemsSameTag) {
-        if (tagNames[0] === 'text') {
-          this.displayTool('text_panel')
-        }
+      if (selElems.every((elem) => elem.tagName === 'text')) {
+        this.displayTool('text_panel')
       }
 
       this.displayTool('multiselected_panel')

--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -437,7 +437,7 @@ class TopPanel {
           this.displayTool('text_panel')
         }
       }
-      
+
       this.displayTool('multiselected_panel')
       menuItems.setAttribute('enablemenuitems', '#group')
       menuItems.setAttribute('disablemenuitems', '#ungroup')

--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -422,6 +422,22 @@ class TopPanel {
 
       // if (elem)
     } else if (this.multiselected) {
+      // Check if all selected elements have the same tag
+      const selElems = this.editor.svgCanvas.getSelectedElements()
+      const tagNames = []
+      selElems.forEach(elem => {
+        const { tagName } = elem
+        tagNames.push(tagName)
+      })
+      const allElemsSameTag = tagNames.every((val, i, arr) => val === arr[0])
+
+      // Enable panels specific for selected elements
+      if (allElemsSameTag) {
+        if (tagNames[0] === 'text') {
+          this.displayTool('text_panel')
+        }
+      }
+      
       this.displayTool('multiselected_panel')
       menuItems.setAttribute('enablemenuitems', '#group')
       menuItems.setAttribute('disablemenuitems', '#ungroup')


### PR DESCRIPTION
## PR description

This PR enables text tool panel wen multiple text elements are selected. This will be extended to other element types in subsequent PR.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
