### PR TITLE
Hide panels when nothing is selected

### DIFF
--- a/src/editor/extensions/ext-polystar/ext-polystar.js
+++ b/src/editor/extensions/ext-polystar/ext-polystar.js
@@ -417,8 +417,13 @@ export default {
       selectedChanged (opts) {
         // Use this to update the current selected elements
         selElems = opts.elems
-
         let i = selElems.length
+        // Hide panels if nothing is selected
+        if (!i) {
+          showPanel(false, 'star')
+          showPanel(false, 'polygon')
+          return
+        }
         while (i--) {
           const elem = selElems[i]
           if (elem?.getAttribute('shape') === 'star') {


### PR DESCRIPTION
## PR description

Hide polystar panels when nothing is selected and user clicks workarea.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
