### PR TITLE
Fix: avoid to generate the same key for two different imported svg

### DIFF
--- a/src/svgcanvas/svg-exec.js
+++ b/src/svgcanvas/svg-exec.js
@@ -21,7 +21,8 @@ import {
   createObjectURL,
   dataURLToObjectURL,
   walkTree,
-  getBBox as utilsGetBBox
+  getBBox as utilsGetBBox,
+  hashCode
 } from './utilities.js'
 import { transformPoint, transformListToTransform } from './math.js'
 import { convertUnit, shortFloat, convertToNum } from '../common/units.js'
@@ -633,7 +634,7 @@ const importSvgString = (xmlString) => {
   let useEl
   try {
     // Get unique ID
-    const uid = encode64(xmlString.length + xmlString).substr(0, 32)
+    const uid = hashCode(xmlString)
 
     let useExisting = false
     // Look for symbol and make sure symbol exists in image

--- a/src/svgcanvas/svg-exec.js
+++ b/src/svgcanvas/svg-exec.js
@@ -17,7 +17,6 @@ import {
   preventClickDefault,
   toXml,
   getStrokedBBoxDefaultVisible,
-  encode64,
   createObjectURL,
   dataURLToObjectURL,
   walkTree,

--- a/src/svgcanvas/utilities.js
+++ b/src/svgcanvas/utilities.js
@@ -149,9 +149,9 @@ export function decode64 (input) {
  * @param word : the string, we want to compute the hashcode
  * @returns {number}: Hascode of the given string
  */
-export function hashCode(word) {
-  let hash = 0;
-  let chr;
+export function hashCode (word) {
+  let hash = 0
+  let chr
   if (word.length === 0) return hash
   for (let i = 0; i < word.length; i++) {
     chr = word.charCodeAt(i)

--- a/src/svgcanvas/utilities.js
+++ b/src/svgcanvas/utilities.js
@@ -145,6 +145,23 @@ export function decode64 (input) {
 }
 
 /**
+ * Compute a hashcode from a given string
+ * @param word : the string, we want to compute the hashcode
+ * @returns {number}: Hascode of the given string
+ */
+export function hashCode(word) {
+  let hash = 0;
+  let chr;
+  if (word.length === 0) return hash
+  for (let i = 0; i < word.length; i++) {
+    chr = word.charCodeAt(i)
+    hash = ((hash << 5) - hash) + chr
+    hash |= 0 // Convert to 32bit integer
+  }
+  return hash
+}
+
+/**
 * @function module:utilities.decodeUTF8
 * @param {string} argString
 * @returns {string}


### PR DESCRIPTION
## PR description

When we import two different but similar svg, it is possible that the code generate the same uid and only one symbol is created in the final svg.

The reason is that the uid is generated by taking a substring of the 32 first characters of the base64 encoding of the imported svg.

I introduice a hashcode method to generate a hash of the imported svg.

I run the tests but it seems that some tests are broken

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [X] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
