### PR TITLE
Fix: applies the transformation of the parent element in addition to …

### DIFF
--- a/packages/svgcanvas/select.js
+++ b/packages/svgcanvas/select.js
@@ -8,7 +8,8 @@
 
 import { isWebkit } from '../../src/common/browser.js'
 import { getRotationAngle, getBBox, getStrokedBBox } from './utilities.js'
-import { transformListToTransform, transformBox, transformPoint } from './math.js'
+import { transformListToTransform, transformBox, transformPoint, matrixMultiply } from './math.js'
+import { NS } from './namespaces'
 
 let svgCanvas
 let selectorManager_ // A Singleton
@@ -105,6 +106,7 @@ export class Selector {
   * @returns {void}
   */
   resize (bbox) {
+    console.info(' -------------- RESIZE -----------------')
     const dataStorage = svgCanvas.getDataStorage()
     const selectedBox = this.selectorRect
     const mgr = selectorManager_
@@ -122,9 +124,28 @@ export class Selector {
       offset += 2 / zoom
     }
 
+    // find the transformations applied to the parent of the selected element
+    const svg = document.createElementNS(NS.SVG, 'svg')
+    let parentTransformationMatrix = svg.createSVGMatrix()
+    let currentElt = selected
+    while (currentElt.parentNode) {
+      if (currentElt.parentNode && currentElt.parentNode.tagName === 'g' && currentElt.parentNode.transform) {
+        if (currentElt.parentNode.transform.baseVal.numberOfItems) {
+          parentTransformationMatrix = matrixMultiply(transformListToTransform(selected.parentNode.transform.baseVal).matrix, parentTransformationMatrix)
+        }
+      }
+      currentElt = currentElt.parentNode
+    }
+
     // loop and transform our bounding box until we reach our first rotation
     const tlist = selected.transform.baseVal
-    const m = transformListToTransform(tlist).matrix
+
+    let m = transformListToTransform(tlist).matrix
+
+    // combines the parent transformation with that of the selected element
+    if (parentTransformationMatrix) {
+      m = matrixMultiply(parentTransformationMatrix, m)
+    }
 
     // This should probably be handled somewhere else, but for now
     // it keeps the selection box correctly positioned when zoomed

--- a/packages/svgcanvas/select.js
+++ b/packages/svgcanvas/select.js
@@ -106,7 +106,6 @@ export class Selector {
   * @returns {void}
   */
   resize (bbox) {
-    console.info(' -------------- RESIZE -----------------')
     const dataStorage = svgCanvas.getDataStorage()
     const selectedBox = this.selectorRect
     const mgr = selectorManager_
@@ -140,12 +139,8 @@ export class Selector {
     // loop and transform our bounding box until we reach our first rotation
     const tlist = selected.transform.baseVal
 
-    let m = transformListToTransform(tlist).matrix
-
-    // combines the parent transformation with that of the selected element
-    if (parentTransformationMatrix) {
-      m = matrixMultiply(parentTransformationMatrix, m)
-    }
+    // combines the parent transformation with that of the selected element if necessary
+    const m = parentTransformationMatrix ? matrixMultiply(parentTransformationMatrix, transformListToTransform(tlist).matrix) : transformListToTransform(tlist).matrix
 
     // This should probably be handled somewhere else, but for now
     // it keeps the selection box correctly positioned when zoomed


### PR DESCRIPTION
This PR may have an impact of this issu #462  

## PR description

The selection rectangle does not appear in the right place when selecting an element that is part of a group that has a transform attribute.
We can reproduce the issue by : 
- importing the following svg element
- ungroup the svg
- double clicking on shape on the element
- select a shape of the element 
- the selection rectangle is not at the right place

![Capture d’écran 2022-10-14 à 14 57 04](https://user-images.githubusercontent.com/90409381/195853221-bbe0ea4d-ceb3-497d-819a-db43cf7875a3.png)

Here is the svg : 
`<svg id="Layer_1" enable-background="new 0 0 511.981 511.981" height="512" viewBox="0 0 511.981 511.981" width="512"
     xmlns="http://www.w3.org/2000/svg">
    <g>
        <path d="m204.694 14.933h102.597v90.178h-102.597z" fill="#c6dcf8"/>
        <path d="m255.993 14.933h51.298v90.178h-51.298z" fill="#82bcea"/>
        <g>
            <path d="m255.993 511.981c-45.594 0-89.074-17.115-122.43-48.191l20.45-21.95c27.784 25.886 64.001 40.142 101.98 40.142 37.977 0 74.193-14.254 101.977-40.138l20.449 21.95c-33.356 31.074-76.834 48.187-122.426 48.187z"
                  fill="#71d5ff"/>
        </g>
        <g>
            <path d="m255.993 459.315c-32.229 0-62.962-12.098-86.541-34.064l20.45-21.95c18.006 16.776 41.478 26.015 66.09 26.015s48.082-9.238 66.088-26.012l20.449 21.95c-23.576 21.965-54.309 34.061-86.536 34.061z"
                  fill="#71d5ff"/>
        </g>
        <g>
            <path d="m255.993 407.199c-18.994 0-37.113-7.135-51.019-20.092l20.45-21.949c8.334 7.765 19.19 12.041 30.569 12.041 11.377 0 22.233-4.276 30.568-12.041l20.449 21.951c-13.906 12.955-32.024 20.09-51.017 20.09z"
                  fill="#71d5ff"/>
        </g>
        <path d="m140.398 75.112h231.138v163.524h-231.138z" fill="#eaf2f9"/>
        <path d="m255.993 75.112h115.543v163.524h-115.543z" fill="#c6dcf8"/>
        <path d="m140.398 208.636v39.737c0 52.158 42.433 94.591 94.591 94.591h41.956c52.158 0 94.591-42.434 94.591-94.591v-39.737z" fill="#c6dcf8"/>
        <path d="m371.536 248.373v-39.737h-115.543v134.328h20.952c52.158 0 94.591-42.433 94.591-94.591z" fill="#82bcea"/>
        <g>
            <path d="m240.992 260.742h30v30.002h-30z" fill="#fd4b49"/>
        </g>
        <g>
            <path d="m155.398 0h201.138v30h-201.138z" fill="#2a4977"/>
        </g>
        <g fill="#52bbef">
            <path d="m357.969 441.844c-27.784 25.883-64 40.138-101.977 40.138v30c45.592 0 89.07-17.113 122.426-48.188z"/>
            <path d="m322.081 403.303c-18.006 16.774-41.476 26.012-66.088 26.012v30c32.227 0 62.96-12.097 86.537-34.062z"/>
            <path d="m286.561 365.159c-8.334 7.765-19.19 12.041-30.568 12.041v30c18.993 0 37.111-7.135 51.017-20.09z"/>
        </g>
        <path d="m255.993 0h100.543v30h-100.543z" fill="#15325b"/>
        <path d="m255.993 260.742h15v30.002h-15z" fill="#e70b69"/>
    </g>
</svg>`

When the element is imported and ungrouped, it contains a transform attribute on a g element wich regroup some of the shapes. 
![Capture d’écran 2022-10-14 à 14 58 10](https://user-images.githubusercontent.com/90409381/195853125-0ebbfbe3-4e99-46c4-b857-c7022bc1f2eb.png)

That is that transformation I try to apply to the selection regtangle in this PR.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
