### PR TITLE
Fix fit to content

### DIFF
--- a/packages/svgcanvas/utilities.js
+++ b/packages/svgcanvas/utilities.js
@@ -974,13 +974,15 @@ export const getVisibleElements = (parentElement) => {
   }
 
   const contentElems = []
-  const children = parentElement.children
-  // eslint-disable-next-line array-callback-return
-  Array.from(children, (elem) => {
-    if (elem.getBBox) {
-      contentElems.push(elem)
-    }
-  })
+  if (parentElement) {
+    const children = parentElement.children
+    // eslint-disable-next-line array-callback-return
+    Array.from(children, (elem) => {
+      if (elem.getBBox) {
+        contentElems.push(elem)
+      }
+    })
+  }
   return contentElems.reverse()
 }
 

--- a/packages/svgcanvas/utilities.js
+++ b/packages/svgcanvas/utilities.js
@@ -962,7 +962,15 @@ export const getStrokedBBox = (elems, addSVGElementsFromJson, pathActions) => {
 export const getVisibleElements = (parentElement) => {
   if (!parentElement) {
     const svgContent = svgCanvas.getSvgContent()
-    parentElement = svgContent.children[0] // Prevent layers from being included
+    for (let i = 0; i < svgContent.children.length; i++) {
+      if (svgContent.children[i].getBBox) {
+        const bbox = svgContent.children[i].getBBox()
+        if (bbox.width !== 0 && bbox.height !== 0 && bbox.width !== 0 && bbox.height !== 0) {
+          parentElement = svgContent.children[i]
+          break
+        }
+      }
+    }
   }
 
   const contentElems = []


### PR DESCRIPTION
## PR description

The feature "fit to content" was broken when nothing is drawing in the canva.
This problem occurs because of the changes of this PR : https://github.com/SVG-Edit/svgedit/pull/840


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
