### PR TITLE
Enhancement: add a parameter to the importSvgString function in order…

### DIFF
--- a/packages/svgcanvas/svg-exec.js
+++ b/packages/svgcanvas/svg-exec.js
@@ -617,6 +617,7 @@ const setSvgString = (xmlString, preventUndo) => {
  * `<use>` to the current layer.
  * @function module:svgcanvas.SvgCanvas#importSvgString
  * @param {string} xmlString - The SVG as XML text.
+ * @param {boolean} preserveDimension - A boolean to force to preserve initial dimension of the imported svg (force svgEdit don't apply a transformation on the imported svg)
  * @fires module:svgcanvas.SvgCanvas#event:changed
  * @returns {null|Element} This function returns null if the import was unsuccessful, or the element otherwise.
  * @todo
@@ -626,7 +627,7 @@ const setSvgString = (xmlString, preventUndo) => {
  * arbitrary transform lists, but makes some assumptions about how the transform list
  * was obtained
  */
-const importSvgString = (xmlString) => {
+const importSvgString = (xmlString, preserveDimension) => {
   const dataStorage = svgCanvas.getDataStorage()
   let j
   let ts
@@ -731,8 +732,10 @@ const importSvgString = (xmlString) => {
     batchCmd.addSubCommand(new InsertElementCommand(useEl))
     svgCanvas.clearSelection()
 
-    useEl.setAttribute('transform', ts)
-    recalculateDimensions(useEl)
+    if (!preserveDimension) {
+      useEl.setAttribute('transform', ts)
+      recalculateDimensions(useEl)
+    }
     dataStorage.put(useEl, 'symbol', symbol)
     dataStorage.put(useEl, 'ref', symbol)
     svgCanvas.addToSelection([useEl])

--- a/src/editor/extensions/ext-opensave/ext-opensave.js
+++ b/src/editor/extensions/ext-opensave/ext-opensave.js
@@ -63,7 +63,7 @@ export default {
       if (file.type.includes('svg')) {
         reader = new FileReader()
         reader.onloadend = (ev) => {
-          const newElement = this.svgCanvas.importSvgString(ev.target.result, true)
+          const newElement = this.svgCanvas.importSvgString(ev.target.result)
           this.svgCanvas.alignSelectedElements('m', 'page')
           this.svgCanvas.alignSelectedElements('c', 'page')
           // highlight imported element, otherwise we get strange empty selectbox

--- a/src/editor/extensions/ext-opensave/ext-opensave.js
+++ b/src/editor/extensions/ext-opensave/ext-opensave.js
@@ -63,7 +63,8 @@ export default {
       if (file.type.includes('svg')) {
         reader = new FileReader()
         reader.onloadend = (ev) => {
-          const newElement = this.svgCanvas.importSvgString(ev.target.result)
+          // imgImport.shiftKey (shift key pressed or not) will determine if import should preserve dimension)
+          const newElement = this.svgCanvas.importSvgString(ev.target.result, imgImport.shiftKey)
           this.svgCanvas.alignSelectedElements('m', 'page')
           this.svgCanvas.alignSelectedElements('c', 'page')
           // highlight imported element, otherwise we get strange empty selectbox
@@ -263,7 +264,8 @@ export default {
         $click($id('tool_open'), clickOpen.bind(this))
         $click($id('tool_save'), clickSave.bind(this, 'save'))
         $click($id('tool_save_as'), clickSave.bind(this, 'saveas'))
-        $click($id('tool_import'), () => imgImport.click())
+        // tool_import pressed with shiftKey will not scale the SVG
+        $click($id('tool_import'), (ev) => { imgImport.shiftKey = ev.shiftKey; imgImport.click() })
       }
     }
   }


### PR DESCRIPTION
## PR description

When importing a svg into another svg, the imported element is systematically set to the scale of the destination svg.  I propose to add a parameter to the import function ("importSvgString") to allow the consumer of the function to decide how the import should be don e: with or without scaling.

This PR is usefull for the users of the svgcanvas package, not for the users of the full editor.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
