### PR TITLE
Code securisation

### DIFF
--- a/packages/svgcanvas/recalculate.js
+++ b/packages/svgcanvas/recalculate.js
@@ -359,7 +359,10 @@ export const recalculateDimensions = (selected) => {
             childTlist.appendItem(scale)
             childTlist.appendItem(translateOrigin)
           } // not rotated
-          batchCmd.addSubCommand(recalculateDimensions(child))
+          const recalculatedDimensions = recalculateDimensions(child)
+          if (recalculatedDimensions) {
+            batchCmd.addSubCommand(recalculatedDimensions)
+          }
           svgCanvas.setStartTransform(oldStartTransform)
         } // element
       } // for each child
@@ -420,7 +423,10 @@ export const recalculateDimensions = (selected) => {
               } else {
                 childTlist.appendItem(newxlate)
               }
-              batchCmd.addSubCommand(recalculateDimensions(child))
+              const recalculatedDimensions = recalculateDimensions(child)
+              if (recalculatedDimensions) {
+                batchCmd.addSubCommand(recalculatedDimensions)
+              }
               // If any <use> have this group as a parent and are
               // referencing this child, then impose a reverse translate on it
               // so that when it won't get double-translated
@@ -464,7 +470,10 @@ export const recalculateDimensions = (selected) => {
           childTlist.clear()
           childTlist.appendItem(e2m, 0)
 
-          batchCmd.addSubCommand(recalculateDimensions(child))
+          const recalculatedDimensions = recalculateDimensions(child)
+          if (recalculatedDimensions) {
+            batchCmd.addSubCommand(recalculatedDimensions)
+          }
           svgCanvas.setStartTransform(oldStartTransform)
 
           // Convert stroke
@@ -544,7 +553,10 @@ export const recalculateDimensions = (selected) => {
               childTlist.appendItem(newxlate)
             }
 
-            batchCmd.addSubCommand(recalculateDimensions(child))
+            const recalculatedDimensions = recalculateDimensions(child)
+            if (recalculatedDimensions) {
+              batchCmd.addSubCommand(recalculatedDimensions)
+            }
             svgCanvas.setStartTransform(oldStartTransform)
           }
         }

--- a/packages/svgcanvas/selected-elem.js
+++ b/packages/svgcanvas/selected-elem.js
@@ -972,7 +972,7 @@ const convertToGroup = elem => {
   } else if (dataStorage.has($elem, 'symbol')) {
     elem = dataStorage.get($elem, 'symbol')
 
-    ts = $elem.getAttribute('transform')
+    ts = $elem.getAttribute('transform') || ''
     const pos = {
       x: Number($elem.getAttribute('x')),
       y: Number($elem.getAttribute('y'))

--- a/packages/svgcanvas/selection.js
+++ b/packages/svgcanvas/selection.js
@@ -324,7 +324,7 @@ const getIntersectionListMethod = (rect) => {
     if (!rubberBBox.width) {
       continue
     }
-    if (rectsIntersect(rubberBBox, curBBoxes[i].bbox)) {
+    if (curBBoxes[i].bbox && rectsIntersect(rubberBBox, curBBoxes[i].bbox)) {
       resultList.push(curBBoxes[i].elem)
     }
   }


### PR DESCRIPTION
## PR description

When importing a svg with a "defs" element, several javascript errors occur when manipulating the element (moving, resizing etc). The errors are mainly due to the fact that the defs element does not have a BBOX and is not a classic graphic element. 
For example, here is a svg that allows you to reproduce the problem: 

```
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<!-- Created with Inkscape (http://www.inkscape.org/) -->

<svg
   width="52.173981mm"
   height="52.916668mm"
   viewBox="0 0 52.17398 52.916668"
   version="1.1"
   id="svg-valve-2w"
   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
   sodipodi:docname="svg-process-valve-3w.svg"
   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
   xmlns="http://www.w3.org/2000/svg"
   xmlns:svg="http://www.w3.org/2000/svg">
  <sodipodi:namedview
     id="valve-2w"
     pagecolor="#505050"
     bordercolor="#eeeeee"
     borderopacity="1"
     inkscape:pageshadow="0"
     inkscape:pageopacity="0"
     inkscape:pagecheckerboard="0"
     inkscape:document-units="mm"
     showgrid="false"
     inkscape:zoom="2.1997092"
     inkscape:cx="205.2544"
     inkscape:cy="182.29682"
     inkscape:window-width="2560"
     inkscape:window-height="1377"
     inkscape:window-x="-8"
     inkscape:window-y="-8"
     inkscape:window-maximized="1"
     inkscape:current-layer="group-valve" />
  <defs
     id="def1" />
  <g
     inkscape:label="Calque 1"
     inkscape:groupmode="layer"
     id="layer1"
     transform="translate(8.9076043e-5,-8.7560385e-5)">
    <g
       id="group-valve"
       transform="matrix(1.1397412,0,0,1.1384284,-31.189183,-14.982723)">
      <g
         id="base-valve"
         style="fill:#110a21;fill-opacity:1;stroke:#e1d9ff;stroke-width:0.264583;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
        <polygon
           class="cls-1"
           points="35.18,0.13 22.65,22.92 10.12,0.13 "
           id="polygon1"
           transform="matrix(0.966206,0,0,1.0162933,27.977226,13.164519)"
           style="fill:#110a21;fill-opacity:1;stroke:#e1d9ff;stroke-width:0.267004;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
        <polygon
           class="cls-1"
           points="10.09,45.6 22.61,22.8 35.14,45.6 "
           id="polygon2"
           transform="matrix(0.966206,0,0,1.0162933,27.977226,13.164519)"
           style="fill:#110a21;fill-opacity:1;stroke:#e1d9ff;stroke-width:0.267004;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
        <polygon
           class="cls-1"
           points="22.61,22.8 35.14,45.6 10.09,45.6 "
           id="polygon2-8"
           transform="matrix(0,-0.9673202,1.0151227,0,26.716994,58.329071)"
           style="fill:#110a21;fill-opacity:1;stroke:#e1d9ff;stroke-width:0.267004;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
      </g>
      <g
         id="base-type"
         style="fill:#e1d9ff;fill-opacity:1"
         transform="translate(-35.56098,0.24056151)">
        <ellipse
           class="cls-5"
           cx="85.249092"
           cy="36.336006"
           rx="4.0190001"
           ry="4.4005499"
           id="ellipse1"
           style="fill:#e1d9ff;fill-opacity:1;stroke-width:0.990933" />
        <rect
           class="cls-5"
           x="72.206825"
           y="34.184132"
           width="9.9422598"
           height="3.9635439"
           id="rect2"
           style="fill:#e1d9ff;fill-opacity:1;stroke-width:0.990933" />
        <rect
           class="cls-2"
           x="63.058338"
           y="22.959854"
           width="10.03888"
           height="26.403299"
           rx="2.2415979"
           id="rect1"
           style="fill:#110a21;fill-opacity:1;stroke:#e1d9ff;stroke-width:0.264583;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1" />
      </g>
    </g>
  </g>
</svg>
```

The errors could be ssen in the following screenshot : 
![Capture d’écran 2022-10-26 à 15 21 02](https://user-images.githubusercontent.com/90409381/198036966-dae3e644-e687-4dcb-80f0-ecf5394e6568.png)


<!-- Add the description of your PR here -->


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
