### PR TITLE
Keep aspect ratio when resizing objects with 'preserveAspectRatio' attr

### DIFF
--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -141,6 +141,9 @@ const mouseMoveEvent = (evt) => {
     y = snapToGrid(y)
   }
 
+  const aspectRatioAttr = selected.getAttribute('preserveAspectRatio').split(' ')
+  const preserveAspectRatio = ['xMinYMin', 'xMidYMin', 'xMaxYMin', 'xMinYMid', 'xMidYMid', 'xMaxYMid', 'xMinYMax', 'xMidYMax', 'xMaxYMax'].includes(aspectRatioAttr[0])
+  
   let tlist
   switch (svgCanvas.getCurrentMode()) {
     case 'select': {
@@ -277,7 +280,7 @@ const mouseMoveEvent = (evt) => {
       }
 
       translateOrigin.setTranslate(-(left + tx), -(top + ty))
-      if (evt.shiftKey) {
+      if (evt.shiftKey || preserveAspectRatio) {
         if (sx === 1) {
           sx = sy
         } else { sy = sx }
@@ -343,7 +346,7 @@ const mouseMoveEvent = (evt) => {
     case 'square':
     case 'rect':
     case 'image': {
-      const square = (svgCanvas.getCurrentMode() === 'square') || evt.shiftKey
+      const square = (svgCanvas.getCurrentMode() === 'square') || evt.shiftKey || preserveAspectRatio
       let
         w = Math.abs(x - svgCanvas.getStartX())
       let h = Math.abs(y - svgCanvas.getStartY())

--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -149,7 +149,6 @@ const mouseMoveEvent = (evt) => {
       preserveAspectRatio = aspectRatioAttrArr.length && ['xMinYMin', 'xMidYMin', 'xMaxYMin', 'xMinYMid', 'xMidYMid', 'xMaxYMid', 'xMinYMax', 'xMidYMax', 'xMaxYMax'].includes(aspectRatioAttrArr[0])
     }
   }
-  
   let tlist
   switch (svgCanvas.getCurrentMode()) {
     case 'select': {

--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -141,8 +141,14 @@ const mouseMoveEvent = (evt) => {
     y = snapToGrid(y)
   }
 
-  const aspectRatioAttr = selected.getAttribute('preserveAspectRatio').split(' ')
-  const preserveAspectRatio = ['xMinYMin', 'xMidYMin', 'xMaxYMin', 'xMinYMid', 'xMidYMid', 'xMaxYMid', 'xMinYMax', 'xMidYMax', 'xMaxYMax'].includes(aspectRatioAttr[0])
+  let preserveAspectRatio = false
+  if (selected) {
+    const aspectRatioAttr = selected.getAttribute('preserveAspectRatio')
+    if (aspectRatioAttr) {
+      const aspectRatioAttrArr = aspectRatioAttr.split(' ')
+      preserveAspectRatio = aspectRatioAttrArr.length && ['xMinYMin', 'xMidYMin', 'xMaxYMin', 'xMinYMid', 'xMidYMid', 'xMaxYMid', 'xMinYMax', 'xMidYMax', 'xMaxYMax'].includes(aspectRatioAttrArr[0])
+    }
+  }
   
   let tlist
   switch (svgCanvas.getCurrentMode()) {


### PR DESCRIPTION
## PR description

This PR adds a check to svgcanvas/event.js to figure out whether the resized object has 'preserveAspectRatio' set. If yes, the aspect ratio of the resized object will be maintained as if the user held shift. This is useful when external objects (e.g. another SVG image) are added where aspect ratio should be preserved.

Since this code now lives in a separate package, I'm not 100% sure whether I have tested it properly.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
