### PR TITLE
Maintain aspect ratio by default for images

### DIFF
--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -277,7 +277,9 @@ const mouseMoveEvent = (evt) => {
       }
 
       translateOrigin.setTranslate(-(left + tx), -(top + ty))
-      if (evt.shiftKey) {
+      // For images, we maintain aspect ratio by default and relax when shift pressed
+      const maintainAspectRatio = (selected.tagName !== 'image' && evt.shiftKey) || (selected.tagName === 'image' && !evt.shiftKey)
+      if (maintainAspectRatio) {
         if (sx === 1) {
           sx = sy
         } else { sy = sx }
@@ -343,12 +345,16 @@ const mouseMoveEvent = (evt) => {
     case 'square':
     case 'rect':
     case 'image': {
-      const square = (svgCanvas.getCurrentMode() === 'square') || evt.shiftKey
+      // For images, we maintain aspect ratio by default and relax when shift pressed
+      const maintainAspectRatio = (svgCanvas.getCurrentMode() === 'square') ||
+        (svgCanvas.getCurrentMode() === 'image' && !evt.shiftKey) ||
+        (svgCanvas.getCurrentMode() !== 'image' && evt.shiftKey)
+
       let
         w = Math.abs(x - svgCanvas.getStartX())
       let h = Math.abs(y - svgCanvas.getStartY())
       let newX; let newY
-      if (square) {
+      if (maintainAspectRatio) {
         w = h = Math.max(w, h)
         newX = svgCanvas.getStartX() < x ? svgCanvas.getStartX() : svgCanvas.getStartX() - w
         newY = svgCanvas.getStartY() < y ? svgCanvas.getStartY() : svgCanvas.getStartY() - h


### PR DESCRIPTION
## PR description

This PR adds code to packages/svgcanvas/event.js to maintain aspect ratio of images by default when adding or resizing (and relax aspect ratio when shift key is pressed). This basically flips the default shift key behavior for images, because in the vast majority of cases maintaining image aspect ratio is the desired outcome from user's perspective.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
