### PR TITLE
Prevent accidental selection move

### DIFF
--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -24,6 +24,7 @@ const {
 } = hstry
 
 let svgCanvas = null
+let moveSelectionThresholdReached = false
 
 /**
 * @function module:undo.init
@@ -155,7 +156,14 @@ const mouseMoveEvent = (evt) => {
           dy = snapToGrid(dy)
         }
 
-        if (dx || dy) {
+        // Enable moving selection only if mouse has been moved at least 4 px in any direction
+        // This prevents objects from being accidentally moved when (initially) selected
+        const deltaThreshold = 4
+        const deltaThresholdReached = Math.abs(dx) > deltaThreshold || Math.abs(dy) > deltaThreshold
+        moveSelectionThresholdReached = moveSelectionThresholdReached || deltaThresholdReached
+        const moveEnabled = deltaThresholdReached || moveSelectionThresholdReached
+
+        if (moveEnabled) {
           selectedElements.forEach((el) => {
             if (el) {
               updateTransformList(svgRoot, el, dx, dy)
@@ -563,6 +571,7 @@ const mouseOutEvent = () => {
 * @returns {void}
 */
 const mouseUpEvent = (evt) => {
+  moveSelectionThresholdReached = false
   if (evt.button === 2) { return }
   if (!svgCanvas.getStarted()) { return }
 

--- a/packages/svgcanvas/event.js
+++ b/packages/svgcanvas/event.js
@@ -161,9 +161,8 @@ const mouseMoveEvent = (evt) => {
         const deltaThreshold = 4
         const deltaThresholdReached = Math.abs(dx) > deltaThreshold || Math.abs(dy) > deltaThreshold
         moveSelectionThresholdReached = moveSelectionThresholdReached || deltaThresholdReached
-        const moveEnabled = deltaThresholdReached || moveSelectionThresholdReached
 
-        if (moveEnabled) {
+        if (moveSelectionThresholdReached) {
           selectedElements.forEach((el) => {
             if (el) {
               updateTransformList(svgRoot, el, dx, dy)


### PR DESCRIPTION
## PR description

This PR adds code to prevent users from accidentally moving objects when (initially) clicking/selecting/shift-selecting. The solution is to enable transform only if mouse is moved more than a set threshold (4 px) in any direction. Whether the threshold has been reached is stored in global variable 'moveSelectionThresholdReached', and reset on mouse up event. 

This is default behavior in Illustrator and others.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
