### PR TITLE
fix: Correct a condition that gets the width value on the Image-Properties

### DIFF
--- a/src/editor/dialogs/imagePropertiesDialog.js
+++ b/src/editor/dialogs/imagePropertiesDialog.js
@@ -280,7 +280,7 @@ export class SeImgPropDialog extends HTMLElement {
   connectedCallback () {
     const onChangeHandler = (ev) => {
       if (!ev.target.selectedIndex) {
-        if (this.$canvasWidth.getAttribute('value') === 'fit') {
+        if (this.$canvasWidth.value === 'fit') {
           this.$canvasWidth.removeAttribute('disabled')
           this.$canvasWidth.value = 100
           this.$canvasHeight.removeAttribute('disabled')


### PR DESCRIPTION
## PR description

When selecting `Fit to Content` the *width* and *height* will be filled with `fit` and they will be disabled for editing, however, when selecting `Select predefined:` directly after that, the input fields would still have `fit` on them and they would still be disabled.
