### PR TITLE
Fix rimraf import

### DIFF
--- a/packages/react-test/rollup.config.mjs
+++ b/packages/react-test/rollup.config.mjs
@@ -5,7 +5,7 @@ import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import replace from '@rollup/plugin-replace'
 
-const { rimraf } = pkg;
+const { rimraf } = pkg
 
 // remove existing distribution
 // remove existing distribution

--- a/packages/react-test/rollup.config.mjs
+++ b/packages/react-test/rollup.config.mjs
@@ -1,9 +1,11 @@
 /* eslint-env node */
-import { rimraf } from 'rimraf'
+import pkg from 'rimraf'
 import babel from '@rollup/plugin-babel'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 import replace from '@rollup/plugin-replace'
+
+const { rimraf } = pkg;
 
 // remove existing distribution
 // remove existing distribution

--- a/packages/svgcanvas/rollup.config.mjs
+++ b/packages/svgcanvas/rollup.config.mjs
@@ -2,7 +2,7 @@
 // This rollup script is run by the command:
 // 'npm run build'
 
-import rimraf from 'rimraf'
+import pkg from 'rimraf'
 import babel from '@rollup/plugin-babel'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'

--- a/packages/svgcanvas/rollup.config.mjs
+++ b/packages/svgcanvas/rollup.config.mjs
@@ -9,7 +9,7 @@ import commonjs from '@rollup/plugin-commonjs'
 // import progress from 'rollup-plugin-progress';
 import filesize from 'rollup-plugin-filesize'
 
-const { rimraf } = pkg;
+const { rimraf } = pkg
 
 // remove existing distribution
 await rimraf('./dist')

--- a/packages/svgcanvas/rollup.config.mjs
+++ b/packages/svgcanvas/rollup.config.mjs
@@ -2,12 +2,14 @@
 // This rollup script is run by the command:
 // 'npm run build'
 
-import { rimraf } from 'rimraf'
+import rimraf from 'rimraf'
 import babel from '@rollup/plugin-babel'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
 import commonjs from '@rollup/plugin-commonjs'
 // import progress from 'rollup-plugin-progress';
 import filesize from 'rollup-plugin-filesize'
+
+const { rimraf } = pkg;
 
 // remove existing distribution
 await rimraf('./dist')

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -4,7 +4,7 @@
 
 import path from 'path'
 import { lstatSync, readdirSync } from 'fs'
-import { rimraf } from 'rimraf'
+import pkg from 'rimraf'
 import babel from '@rollup/plugin-babel'
 import copy from 'rollup-plugin-copy'
 import { nodeResolve } from '@rollup/plugin-node-resolve'
@@ -15,6 +15,8 @@ import html from 'rollup-plugin-html'
 import dynamicImportVars from '@rollup/plugin-dynamic-import-vars'
 // import progress from 'rollup-plugin-progress';
 import filesize from 'rollup-plugin-filesize'
+
+const { rimraf } = pkg
 
 // utility function
 const getDirectories = (source) => {


### PR DESCRIPTION
## PR description

This fixes rimraf import from:
import { rimraf } from rimraf

To:
import pkg from 'rimraf';
const { rimraf } = pkg;

The current import is incorrect and breaks in certain environments:
[!] SyntaxError: Named export 'rimraf' not found. The requested module 'rimraf' is a CommonJS module, which may not support all module.exports as named exports.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
