### PR TITLE
fix: Enhance text properties for multiple selected elements (SVG-Edit/svgedit#918)

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -470,7 +470,7 @@ class Editor extends EditorStartup {
     const isNode = mode === 'pathedit'
     // if this.elems[1] is present, then we have more than one element
     this.selectedElement = elems.length === 1 || !elems[1] ? elems[0] : null
-    this.multiselected = elems.length >= 2 && elems[1]
+    this.multiselected = elems.length >= 2 && !!elems[1]
     if (this.selectedElement && !isNode) {
       this.topPanel.update()
     } // if (elem)


### PR DESCRIPTION
This commit addresses issue SVG-Edit/svgedit#918 by improving text property handling when multiple elements are selected. You can now set Bold, Italic, Text-Decoration, Text-Anchor, Letter-Spacing, Word-Spacing, Text Length, and Length Adjust.