### PR TITLE
fix: Call zoomChanged event after updating the zoom

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -824,6 +824,7 @@ class Editor extends EditorStartup {
    * @param {module:svgcanvas.SvgCanvas#event:zoomed} bbox
    * @param {boolean} autoCenter
    * @listens module:svgcanvas.SvgCanvas#event:zoomed
+   * @fires module:svgcanvas.SvgCanvas#event:ext_zoomChanged
    * @returns {void}
    */
   zoomChanged (win, bbox, autoCenter) {
@@ -865,6 +866,11 @@ class Editor extends EditorStartup {
     }
 
     this.zoomDone()
+
+    this.svgCanvas.runExtensions(
+      'zoomChanged',
+      /** @type {module:svgcanvas.SvgCanvas#event:ext_zoomChanged} */ this.svgCanvas.getZoom()
+    )
   }
 
   /**


### PR DESCRIPTION
The zoomChange method was not being called on the extensions, and this commit fixes this by calling the runExtensions method after updating the zoom.
This commit addresses issue SVG-Edit/svgedit#896
