### PR TITLE
Cursor

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -96,6 +96,7 @@ class Editor extends EditorStartup {
       'zh-CN',
       'zh-TW'
     ]
+    
     const modKey = isMac() ? 'meta+' : 'ctrl+'
     this.shortcuts = [
       // Shortcuts not associated with buttons
@@ -304,6 +305,14 @@ class Editor extends EditorStartup {
         fn: () => {
           this.pasteInCenter()
         }
+      },
+      {
+        key: 'escape',
+        fn: () => {
+          if (this.enableToolCancel) {
+            this.cancelTool()
+          }
+          }
       }
     ]
     this.leftPanel = new LeftPanel(this)

--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -122,6 +122,11 @@ class EditorStartup {
     this.modeEvent = this.svgCanvas.modeEvent
     document.addEventListener('modeChange', (evt) => this.modeListener(evt))
 
+    /**if true - selected tool can be cancelled with Esc key
+     * disables on dragging (mousedown) to avoid changing mode in the middle of drawing
+    */
+    this.enableToolCancel = true 
+
     //custom cursor element (appears when some modes (e.g. ellipse) are active)
     // const cursorDiv = document.createElement('div')
     // cursorDiv.setAttribute('id', 'editor-cursor')
@@ -319,6 +324,7 @@ class EditorStartup {
       return false
     })
     $id('svgcanvas').addEventListener('mousedown', (evt) => {
+      this.enableToolCancel = false
       if (evt.button === 1 || keypan === true) {
         // prDefault to avoid firing of browser's panning on mousewheel
         evt.preventDefault()
@@ -341,6 +347,7 @@ class EditorStartup {
     })
 
     window.addEventListener('mouseup', (evt) => {
+      this.enableToolCancel = true
       if (evt.button === 1) {
         this.svgCanvas.setMode(previousMode ?? 'select')
       }
@@ -774,6 +781,18 @@ class EditorStartup {
     }
 
     this.workarea.style.cursor = cs
+  }
+
+  /**
+   * Listens for Esc key to be pressed to cancel active mode, sets mode to Select
+   */
+  cancelTool() {
+    const mode = this.svgCanvas.getMode()
+    //list of modes that are currently save to cancel
+    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper']
+    if (modesToCancel.includes(mode)) {
+      this.leftPanel.clickSelect()
+    }
   }
 
   /**

--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -122,6 +122,16 @@ class EditorStartup {
     this.modeEvent = this.svgCanvas.modeEvent
     document.addEventListener('modeChange', (evt) => this.modeListener(evt))
 
+    //custom cursor element (appears when some modes (e.g. ellipse) are active)
+    // const cursorDiv = document.createElement('div')
+    // cursorDiv.setAttribute('id', 'editor-cursor')
+    // this.cursor = cursorDiv
+    // this.setCursorCoorinates(0, 0)
+    // document.body.appendChild(cursorDiv)
+
+    // this.workarea.addEventListener('mousemove', (e) => this.handleCursorMove(e))
+    // this.workarea.addEventListener('mouseleave', () => this.setCursorCoorinates(-100, -100))
+
     this.leftPanel.init()
     this.bottomPanel.init()
     this.topPanel.init()
@@ -747,11 +757,44 @@ class EditorStartup {
       case 'zoom':
         cs = 'crosshair'
         break
+      case 'circle':
+      case 'ellipse':
+      case 'rect':
+      case 'square':
+      case 'star':
+      case 'polygon':
+        cs = `url("./images/cursors/${mode}_cursor.svg"), crosshair`
+        break
+      case 'text':
+        //#TODO: Cursor should be changed back to default after text element was created
+        cs = 'text';
+        break
       default:
         cs = 'auto'
     }
 
     this.workarea.style.cursor = cs
+  }
+
+  /**
+   * Listens to the mouse coordinates when ose is moving on workarea
+   * @param {Event} e - mosemove Event 
+   */
+  handleCursorMove(e) {
+    const x = e.clientX
+    const y = e.clientY
+
+    this.setCursorCoorinates(x, y)
+  }
+
+  /**
+   * Sets new coordinates for the custom cursor
+   * @param {number} x
+   * @param {number} y
+   */
+  setCursorCoorinates(x, y) {
+    this.cursor.style.left = x + 2 + 'px'
+    this.cursor.style.top = y + 2 + 'px'
   }
 }
 

--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -127,16 +127,6 @@ class EditorStartup {
     */
     this.enableToolCancel = true 
 
-    //custom cursor element (appears when some modes (e.g. ellipse) are active)
-    // const cursorDiv = document.createElement('div')
-    // cursorDiv.setAttribute('id', 'editor-cursor')
-    // this.cursor = cursorDiv
-    // this.setCursorCoorinates(0, 0)
-    // document.body.appendChild(cursorDiv)
-
-    // this.workarea.addEventListener('mousemove', (e) => this.handleCursorMove(e))
-    // this.workarea.addEventListener('mouseleave', () => this.setCursorCoorinates(-100, -100))
-
     this.leftPanel.init()
     this.bottomPanel.init()
     this.topPanel.init()
@@ -793,27 +783,6 @@ class EditorStartup {
     if (modesToCancel.includes(mode)) {
       this.leftPanel.clickSelect()
     }
-  }
-
-  /**
-   * Listens to the mouse coordinates when ose is moving on workarea
-   * @param {Event} e - mosemove Event 
-   */
-  handleCursorMove(e) {
-    const x = e.clientX
-    const y = e.clientY
-
-    this.setCursorCoorinates(x, y)
-  }
-
-  /**
-   * Sets new coordinates for the custom cursor
-   * @param {number} x
-   * @param {number} y
-   */
-  setCursorCoorinates(x, y) {
-    this.cursor.style.left = x + 2 + 'px'
-    this.cursor.style.top = y + 2 + 'px'
   }
 }
 

--- a/src/editor/components/seButton.js
+++ b/src/editor/components/seButton.js
@@ -5,7 +5,7 @@ template.innerHTML = `
   <style>
   @keyframes btnHover {
     from {
-      background-color: transparent;
+      background-color: var(--main-bg-color);
     }
 
     to {

--- a/src/editor/components/seButton.js
+++ b/src/editor/components/seButton.js
@@ -3,9 +3,18 @@ import { t } from '../locale.js'
 const template = document.createElement('template')
 template.innerHTML = `
   <style>
+  @keyframes btnHover {
+    from {
+      background-color: transparent;
+    }
+
+    to {
+      background-color: var(--icon-bg-color-hover);
+    }
+  }
   :host(:hover) :not(.disabled)
   {
-    background-color: var(--icon-bg-color-hover);
+    animation: btnHover 0.2s forwards;
   }
   div
   {

--- a/src/editor/components/seFlyingButton.js
+++ b/src/editor/components/seFlyingButton.js
@@ -39,9 +39,17 @@ export class FlyingButton extends HTMLElement {
         :host {
           position:relative;
         }
-        .overall:hover *
-        {
-          background-color: var(--icon-bg-color-hover);
+        @keyframes btnHover {
+          from {
+            background-color: transparent;
+          }
+
+          to {
+            background-color: var(--icon-bg-color-hover);
+          }
+        }
+        .overall .menu-button:hover {
+          animation: btnHover 0.2s forwards;
         }
         img {
           border: none;

--- a/src/editor/components/seZoom.js
+++ b/src/editor/components/seZoom.js
@@ -44,6 +44,23 @@ template.innerHTML = `
     margin-top: 2px;
     margin-bottom: 1px;
   }
+  #arrow-up, #arrow-down {
+    user-select: none;
+  }
+  @keyframes hover-arrows {
+    from {
+      background: transparent;
+      color: var(--icon-bg-color-hover);
+    }
+
+    to {
+      background: var(--icon-bg-color-hover);
+      color: var(--orange-color);
+    }
+  }
+  #arrow-up:hover, #arrow-down:hover {
+    animation: hover-arrows 0.2s forwards;
+  }
   #down{
     width:18px;
     height:23px;

--- a/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
+++ b/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
@@ -83,6 +83,7 @@ export default {
       callback () {
         // Add the button and its handler(s)
         const title = `${name}:buttons.0.title`
+        //#TODO: Come up with another shortcut (?) because 'I' is reserved for italic
         const key = `${name}:buttons.0.key`
         const buttonTemplate = `
         <se-button id="tool_eyedropper" title="${title}" src="eye_dropper.svg" shortcut=${key}></se-button>

--- a/src/editor/images/cursors/circle_cursor.svg
+++ b/src/editor/images/cursors/circle_cursor.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<svg width="20" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1">
+    <title>circle_cursor</title>
+    <g class="layer">
+        <title>Layer 1</title>
+        <g id="layer2">
+            <path d="m0.1,7.76l7.7,-7.66l-7.7,0l0,7.66z" fill="#2b3c45" id="path9" stroke="#2b3c45"
+                stroke-dashoffset="0" stroke-width="0.19" />
+        </g>
+
+        <circle cx="9.44" cy="9.06" display="inline" fill="#ffffff" id="path10" r="5.98" stroke="#2b3c45"
+            stroke-dashoffset="0" stroke-width="1" />
+    </g>
+</svg>

--- a/src/editor/images/cursors/ellipse_cursor.svg
+++ b/src/editor/images/cursors/ellipse_cursor.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<svg width="20" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1">
+    <title>circle_cursor</title>
+    <g class="layer">
+        <title>Layer 1</title>
+        <g class="layer" id="svg_2">
+            <g id="layer2">
+                <path d="m0.1,6.37l6.3,-6.27l-6.3,0l0,6.27z" fill="#2b3c45" id="path9" stroke="#2b3c45"
+                    stroke-dashoffset="0" stroke-width="0.2" />
+            </g>
+            <ellipse cx="11.0" cy="7" fill="#ffffff" id="svg_1" rx="7.5" ry="3.43" stroke="#2b3c45" stroke-width="1" />
+        </g>
+    </g>
+</svg>

--- a/src/editor/images/cursors/rect_cursor.svg
+++ b/src/editor/images/cursors/rect_cursor.svg
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<svg width="20" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1">
+    <title>circle_cursor</title>
+    <g class="layer">
+        <title>Layer 1</title>
+        <g class="layer" id="svg_2">
+
+            <path d="m0.1,6.37l6.3,-6.27l-6.3,0l0,6.27z" fill="#2b3c45" id="path9" stroke="#2b3c45"
+                stroke-dashoffset="0" stroke-width="0.2" />
+
+        </g>
+        <rect fill="#ffffff" height="6.4" id="svg_3" stroke="#2b3c45" width="13.6" x="4.54" y="4.53" />
+    </g>
+</svg>

--- a/src/editor/images/cursors/square_cursor.svg
+++ b/src/editor/images/cursors/square_cursor.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0"?>
+<svg width="20" height="16" xmlns="http://www.w3.org/2000/svg" xmlns:svg="http://www.w3.org/2000/svg" version="1.1">
+ <title>circle_cursor</title>
+ <g class="layer">
+  <title>Layer 1</title>
+  <g class="layer" id="svg_2">
+   <g id="layer2">
+    <path d="m0.1,6.37l6.3,-6.27l-6.3,0l0,6.27z" fill="#2b3c45" id="path9" stroke="#2b3c45" stroke-dashoffset="0" stroke-width="0.2"/>
+   </g>
+  </g>
+  <rect fill="#ffffff" height="8" id="svg_3" stroke="#2b3c45" width="8" x="5.04" y="4.43"/>
+ </g>
+</svg>

--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -763,15 +763,25 @@ class TopPanel {
       this.editor.svgCanvas.moveToBottomSelectedElement()
     }
   }
+  /**
+   * Checks if there are currently selected text elements to avoid firing of bold,italic when no text selected
+   * @returns {boolean}
+   */
+  get anyTextSelected() {
+    const selected = this.editor.svgCanvas.getSelectedElements()
+    return selected.filter(el => el.tagName === 'text').length > 0
+  }
 
   /**
    *
    * @returns {false}
    */
   clickBold () {
-    this.editor.svgCanvas.setBold(!this.editor.svgCanvas.getBold())
-    this.updateContextPanel()
-    return false
+    if (this.anyTextSelected) {
+      this.editor.svgCanvas.setBold(!this.editor.svgCanvas.getBold())
+      this.updateContextPanel()
+      return false
+    }
   }
 
   /**
@@ -779,10 +789,7 @@ class TopPanel {
    * @returns {false}
    */
   clickItalic () {
-    //Checks if there are currently selected text elements
-    const selected = this.editor.svgCanvas.getSelectedElements()
-    const anyTextSelected = selected.length > 0 && selected.filter(el => el.tagName === 'text').length > 0
-    if (anyTextSelected) {
+    if (this.anyTextSelected) {
       this.editor.svgCanvas.setItalic(!this.editor.svgCanvas.getItalic())
       this.updateContextPanel()
       return false

--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -779,9 +779,14 @@ class TopPanel {
    * @returns {false}
    */
   clickItalic () {
-    this.editor.svgCanvas.setItalic(!this.editor.svgCanvas.getItalic())
-    this.updateContextPanel()
-    return false
+    //Checks if there are currently selected text elements
+    const selected = this.editor.svgCanvas.getSelectedElements()
+    const anyTextSelected = selected.length > 0 && selected.filter(el => el.tagName === 'text').length > 0
+    if (anyTextSelected) {
+      this.editor.svgCanvas.setItalic(!this.editor.svgCanvas.getItalic())
+      this.updateContextPanel()
+      return false
+    }
   }
 
   /**

--- a/src/editor/svgedit.css
+++ b/src/editor/svgedit.css
@@ -8,6 +8,7 @@
   --icon-bg-color: #72797A;
   --icon-bg-color-hover: #2B3C45;
   --input-color: #B2B2B2;
+  --orange-color: #f9bc01;
   --global-se-spin-input-width: 82px;
 }
 


### PR DESCRIPTION
## PR description

-- more specific cursors for _Circle_, _Ellipse, Square_ and _Rectangle_ tools

-- `Esc` key cancels the currently selected tool. It applies only for _Zoom, Rect, Square, Circle, Ellipse, Line, Text, Star, Polygon,_ and _Eyedropper_. Cancelation with the `Esc` key is disabled if pressed in the middle of using those tools (e.g. in the middle of drawing a new circle) to avoid unexpected behaviour;

-- `I` and `B` shortcuts for _italic_ and _bold_ text are unavailable if no text element is selected - currently, when pressing those keys nothing happens and other shortcuts (e.g. E for Ellipse) become unavailable until refresh (app throws an error);

-- minor styling changes

