### PR TITLE
fix #832, floating btns closing, Esc to close confirmation dialog, 0x0 rects disabled

### DIFF
--- a/packages/svgcanvas/core/event.js
+++ b/packages/svgcanvas/core/event.js
@@ -713,7 +713,9 @@ const mouseUpEvent = (evt) => {
       const width = element.getAttribute('width')
       const height = element.getAttribute('height')
       // Image should be kept regardless of size (use inherit dimensions later)
-      keep = (width || height) || svgCanvas.getCurrentMode() === 'image'
+      const widthNum = Number(width)
+      const heightNum = Number(height)
+      keep = widthNum >= 1 || heightNum >= 1 || svgCanvas.getCurrentMode() === 'image'
     }
       break
     case 'circle':

--- a/packages/svgcanvas/core/event.js
+++ b/packages/svgcanvas/core/event.js
@@ -886,8 +886,8 @@ const mouseUpEvent = (evt) => {
       if (svgCanvas.getCurrentMode() === 'path') {
         svgCanvas.pathActions.toEditMode(element)
       } else if (svgCanvas.getCurConfig().selectNew) {
-        const modes = ['circle', 'ellipse', 'square', 'rect', 'fhpath', 'line', 'fhellipse', 'fhrect', 'star', 'polygon']
-        if (modes.indexOf(svgCanvas.getCurrentMode()) !== -1) {
+        const modes = ['circle', 'ellipse', 'square', 'rect', 'fhpath', 'line', 'fhellipse', 'fhrect', 'star', 'polygon', 'shapelib']
+        if (modes.indexOf(svgCanvas.getCurrentMode()) !== -1 && !evt.altKey) {
           svgCanvas.setMode('select')
         }
         svgCanvas.selectOnly([element], true)

--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -752,6 +752,7 @@ class EditorStartup {
         cs = 'grab'
         break
       case 'zoom':
+      case 'shapelib':
         cs = 'crosshair'
         break
       case 'circle':
@@ -779,7 +780,7 @@ class EditorStartup {
   cancelTool () {
     const mode = this.svgCanvas.getMode()
     // list of modes that are currently save to cancel
-    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper']
+    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper', 'shapelib']
     if (modesToCancel.includes(mode)) {
       this.leftPanel.clickSelect()
     }

--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -780,7 +780,7 @@ class EditorStartup {
   cancelTool () {
     const mode = this.svgCanvas.getMode()
     // list of modes that are currently save to cancel
-    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper', 'shapelib']
+    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper', 'shapelib', 'image']
     if (modesToCancel.includes(mode)) {
       this.leftPanel.clickSelect()
     }

--- a/src/editor/components/seExplorerButton.js
+++ b/src/editor/components/seExplorerButton.js
@@ -26,7 +26,7 @@ export class ExplorerButton extends HTMLElement {
     this.request = new XMLHttpRequest()
     this.imgPath = svgEditor.configObj.curConfig.imgPath
 
-    // Closes opened (pressed) lib menu on click on the canvas
+    //Closes opened (pressed) lib menu on click on the canvas
     const workarea = document.getElementById('workarea')
     workarea.addEventListener('click', (e) => {
       this.$menu.classList.remove('open')

--- a/src/editor/components/seExplorerButton.js
+++ b/src/editor/components/seExplorerButton.js
@@ -25,6 +25,13 @@ export class ExplorerButton extends HTMLElement {
     this.files = []
     this.request = new XMLHttpRequest()
     this.imgPath = svgEditor.configObj.curConfig.imgPath
+
+    // Closes opened (pressed) lib menu on click on the canvas
+    const workarea = document.getElementById('workarea')
+    workarea.addEventListener('click', (e) => {
+      this.$menu.classList.remove('open')
+      this.$lib.classList.remove('open-lib')
+    })
   }
 
   /**
@@ -262,8 +269,8 @@ export class ExplorerButton extends HTMLElement {
       ev.stopPropagation()
       switch (ev.target.nodeName) {
         case 'SE-EXPLORERBUTTON':
-          this.$menu.classList.add('open')
-          this.$lib.classList.add('open-lib')
+          this.$menu.classList.toggle('open')
+          this.$lib.classList.toggle('open-lib')
           break
         case 'SE-BUTTON':
         // change to the current action

--- a/src/editor/components/seExplorerButton.js
+++ b/src/editor/components/seExplorerButton.js
@@ -26,7 +26,7 @@ export class ExplorerButton extends HTMLElement {
     this.request = new XMLHttpRequest()
     this.imgPath = svgEditor.configObj.curConfig.imgPath
 
-    //Closes opened (pressed) lib menu on click on the canvas
+    // Closes opened (pressed) lib menu on click on the canvas
     const workarea = document.getElementById('workarea')
     workarea.addEventListener('click', (e) => {
       this.$menu.classList.remove('open')

--- a/src/editor/components/seFlyingButton.js
+++ b/src/editor/components/seFlyingButton.js
@@ -25,7 +25,7 @@ export class FlyingButton extends HTMLElement {
     // we retrieve all elements added in the slot (i.e. se-buttons)
     this.$elements = this.$menu.lastElementChild.assignedElements()
 
-    //Closes opened menu on click
+    // Closes opened menu on click
     document.addEventListener('click', e => {
       if (this.opened) {
         this.opened = false

--- a/src/editor/components/seFlyingButton.js
+++ b/src/editor/components/seFlyingButton.js
@@ -24,6 +24,13 @@ export class FlyingButton extends HTMLElement {
     // the last element of the div is the slot
     // we retrieve all elements added in the slot (i.e. se-buttons)
     this.$elements = this.$menu.lastElementChild.assignedElements()
+
+    //Closes opened menu on click
+    document.addEventListener('click', e => {
+      if (this.opened) {
+        this.opened = false
+      }
+    })
   }
 
   /**

--- a/src/editor/dialogs/SePlainAlertDialog.js
+++ b/src/editor/dialogs/SePlainAlertDialog.js
@@ -66,7 +66,7 @@ export default class SePlainAlertDialog extends PlainAlertDialog {
 
   /**
    * Tracks if users wants to cancel (close dialog without any changes) with Esc
-   * if null - seConfirm will use responce.choice 
+   * if null - seConfirm will use responce.choice
    */
   keyChoice = null
 

--- a/src/editor/dialogs/SePlainAlertDialog.js
+++ b/src/editor/dialogs/SePlainAlertDialog.js
@@ -1,5 +1,5 @@
 import PlainAlertDialog from 'elix/src/plain/PlainAlertDialog.js'
-import { template } from 'elix/src/base/internal.js'
+import { template, keydown } from 'elix/src/base/internal.js'
 import { fragmentFrom } from 'elix/src/core/htmlLiterals.js'
 
 /**
@@ -62,6 +62,24 @@ export default class SePlainAlertDialog extends PlainAlertDialog {
       `
     )
     return result
+  }
+
+  /**
+   * Tracks if users wants to cancel (close dialog without any changes) with Esc
+   * if null - seConfirm will use responce.choice 
+   */
+  keyChoice = null
+
+  get [keydown] () {
+    /**
+     * Listens to Esc key to close dialog
+     */
+    return (e) => {
+      if (e.key === 'Escape') {
+        this.keyChoice = 'Cancel'
+        this.close()
+      }
+    }
   }
 }
 

--- a/src/editor/dialogs/seConfirmDialog.js
+++ b/src/editor/dialogs/seConfirmDialog.js
@@ -6,7 +6,7 @@ const seConfirm = async (text, choices) => {
   dialog.choices = (choices === undefined) ? ['Ok', 'Cancel'] : choices
   dialog.open()
   const response = await dialog.whenClosed()
-  return response.choice
+  return dialog.keyChoice ?? response.choice
 }
 
 window.seConfirm = seConfirm


### PR DESCRIPTION
## PR description

-- `Esc` key cancels the dialog window appearing before creating a new document (N) or opening new svg file (atm Esc key acts as Enter and selects currently focused button (usually it's an "Ok" choice) which is a bit confusing);

-- Floating buttons (e.g. _Shape Library_ or _Rect/Square/Rect by hand_) can be closed by clicking somewhere in the document (_shapeLibrary_ - by clicking on the workarea and button itself, not only on the handle);

-- _ShapeLibrary_ can be cancelled with Esc key (same as [here](https://github.com/SVG-Edit/svgedit/pull/946));

-- Drawing of 0x0 rectangles/squares is disabled (atm a simple click while in _rect_ or _square_ creates such figure)

-- Addressing #832 - the mode will not change to _select_ if `Alt` was pressed. I've chosen this key because Shift is reserved for Circle/Square while drawing Ellipses/Rect.

-- after drawing a shape from the _Shape Library_ (if `Alt` is not pressed) the mode changes to _'select'_ (same as with other tools, atm after drawing a shape mode doesn't change automatically)

