### PR TITLE
Enhancement: Eyedropper

### DIFF
--- a/src/editor/EditorStartup.js
+++ b/src/editor/EditorStartup.js
@@ -780,7 +780,7 @@ class EditorStartup {
   cancelTool () {
     const mode = this.svgCanvas.getMode()
     // list of modes that are currently save to cancel
-    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'eyedropper', 'shapelib', 'image']
+    const modesToCancel = ['zoom', 'rect', 'square', 'circle', 'ellipse', 'line', 'text', 'star', 'polygon', 'shapelib', 'image']
     if (modesToCancel.includes(mode)) {
       this.leftPanel.clickSelect()
     }

--- a/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
+++ b/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
@@ -40,14 +40,14 @@ export default {
     helperCursor.style.height = '14px'
     helperCursor.style.position = 'absolute'
     svgEditor.workarea.appendChild(helperCursor)
-    
+
     const styleHelper = () => {
       const mode = svgCanvas.getMode()
 
       if (mode === name) {
         helperCursor.style.display = 'block'
 
-        const strokeWidthNum = Number(currentStyle.strokeWidth);
+        const strokeWidthNum = Number(currentStyle.strokeWidth)
         const borderStyle = currentStyle.strokeDashArray === 'none' || !currentStyle.strokeDashArray ? 'solid' : 'dotted'
 
         helperCursor.style.background = currentStyle.fillPaint ?? 'transparent'
@@ -77,7 +77,6 @@ export default {
      * @returns {void}
      */
     const getStyle = (opts) => {
-
       let elem = null
       if (!opts.multiselected && opts.elems[0] &&
         !['svg', 'g', 'use'].includes(opts.elems[0].nodeName)
@@ -125,7 +124,7 @@ export default {
           }
         })
 
-        //Positions helper
+        // Positions helper
         svgEditor.workarea.addEventListener('mousemove', (e) => {
           const x = e.clientX
           const y = e.clientY
@@ -135,7 +134,6 @@ export default {
             helperCursor.style.left = x + 12 + 'px'
             styleHelper()
           }
-          
         })
 
         svgEditor.workarea.addEventListener('mouseleave', e => {
@@ -161,12 +159,11 @@ export default {
 
             // If some style is picked - applies it to the target, if no style - picks it from the target
             if (Object.keys(currentStyle).length > 0) {
-
               const change = function (elem, attrname, newvalue) {
                 changes[attrname] = elem.getAttribute(attrname)
                 elem.setAttribute(attrname, newvalue)
               }
-  
+
               if (currentStyle.fillPaint) { change(target, 'fill', currentStyle.fillPaint) }
               if (currentStyle.fillOpacity) { change(target, 'fill-opacity', currentStyle.fillOpacity) }
               if (currentStyle.strokePaint) { change(target, 'stroke', currentStyle.strokePaint) }
@@ -176,12 +173,11 @@ export default {
               if (currentStyle.opacity) { change(target, 'opacity', currentStyle.opacity) }
               if (currentStyle.strokeLinecap) { change(target, 'stroke-linecap', currentStyle.strokeLinecap) }
               if (currentStyle.strokeLinejoin) { change(target, 'stroke-linejoin', currentStyle.strokeLinejoin) }
-  
+
               addToHistory(new ChangeElementCommand(target, changes))
             } else {
-              getStyle({elems: [target]})
+              getStyle({ elems: [target] })
             }
-
           }
         }
       }

--- a/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
+++ b/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
@@ -47,9 +47,12 @@ export default {
       if (mode === name) {
         helperCursor.style.display = 'block'
 
+        const strokeWidthNum = Number(currentStyle.strokeWidth);
+        const borderStyle = currentStyle.strokeDashArray === 'none' || !currentStyle.strokeDashArray ? 'solid' : 'dotted'
+
         helperCursor.style.background = currentStyle.fillPaint ?? 'transparent'
         helperCursor.style.opacity = currentStyle.opacity ?? 1
-        helperCursor.style.border = (Number(currentStyle.strokeWidth) > 0 && currentStyle.strokePaint) ? `1px solid ${currentStyle.strokePaint}` : 'none'
+        helperCursor.style.border = (strokeWidthNum > 0 && currentStyle.strokePaint) ? `2px ${borderStyle} ${currentStyle.strokePaint}` : 'none'
       }
     }
 
@@ -74,9 +77,6 @@ export default {
      * @returns {void}
      */
     const getStyle = (opts) => {
-      // if we are in eyedropper mode, we don't want to disable the eye-dropper tool
-      // const mode = svgCanvas.getMode()
-      // if (mode === name) { return }
 
       let elem = null
       if (!opts.multiselected && opts.elems[0] &&
@@ -151,7 +151,6 @@ export default {
       },
       // if we have selected an element, grab its paint and enable the eye dropper button
       selectedChanged: getStyle,
-      elementChanged: getStyle,
       mouseDown (opts) {
         const mode = svgCanvas.getMode()
         if (mode === name) {
@@ -160,7 +159,7 @@ export default {
           if (!['svg', 'g', 'use'].includes(target.nodeName)) {
             const changes = {}
 
-            // If some style is picked - applies it to the target, if no style - picks it from target
+            // If some style is picked - applies it to the target, if no style - picks it from the target
             if (Object.keys(currentStyle).length > 0) {
 
               const change = function (elem, attrname, newvalue) {

--- a/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
+++ b/src/editor/extensions/ext-eyedropper/ext-eyedropper.js
@@ -169,10 +169,15 @@ export default {
               if (currentStyle.strokePaint) { change(target, 'stroke', currentStyle.strokePaint) }
               if (currentStyle.strokeOpacity) { change(target, 'stroke-opacity', currentStyle.strokeOpacity) }
               if (currentStyle.strokeWidth) { change(target, 'stroke-width', currentStyle.strokeWidth) }
-              if (currentStyle.strokeDashArray) { change(target, 'stroke-dasharray', currentStyle.strokeDashArray) }
               if (currentStyle.opacity) { change(target, 'opacity', currentStyle.opacity) }
               if (currentStyle.strokeLinecap) { change(target, 'stroke-linecap', currentStyle.strokeLinecap) }
               if (currentStyle.strokeLinejoin) { change(target, 'stroke-linejoin', currentStyle.strokeLinejoin) }
+
+              if (currentStyle.strokeDashArray) {
+                change(target, 'stroke-dasharray', currentStyle.strokeDashArray)
+              } else {
+                target.removeAttribute('stroke-dasharray')
+              }
 
               addToHistory(new ChangeElementCommand(target, changes))
             } else {


### PR DESCRIPTION
## PR description

More intuitive Eyedropper tool:

-- Tool can have one of 2 states - **empty** (no style is picked, click on an element picks its style) and where **style was picked** (click on an element applies a picked style on it). By default once the tool is chosen it has an empty state, if some elements are selected by that time it picks the first selected element's style (same as before);

-- The helper near the cursor was added to help differentiate between 2 states - it doesn't appear if the state is empty and, once some style was picked, it appears as a small div styled according to a picked style

-- `Esc` resets picked style (if the state is non-empty) or sets _Select_ mode (if the state is empty). 

https://github.com/SVG-Edit/svgedit/assets/96601180/5c965154-22b2-481e-947b-704a0a661e78

-- Shortcut changed to `Ctrl + I` since `I` is reserved for Italic text

-- Fixed a bug where an element with a dashed stroke doesn't inherit style with the solid stroke. To reproduce:
1. Set dash-array style as solid
2. Create an element (e.g. Ellipse) with a solid stroke 
3. Create a second element (e.g. Rectangle) and apply any dashed stroke style to it
4. Select an element with a solid stroke only (so its style will be picked by the old eyedropper)
5. Click the Eyedropper tool and try to apply the picked style (with a solid stroke) to the second element (with a dashed stroke) - the second element will inherit the picked style but the stroke will remain dashed

