### PR TITLE
Fix main file path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "svgedit",
   "version": "7.3.3",
   "description": "Powerful SVG-Editor for your browser ",
-  "main": "dist/Editor.js",
-  "module": "dist/Editor.js",
+  "main": "dist/editor/Editor.js",
+  "module": "dist/editor/Editor.js",
   "directories": {
     "doc": "docs",
     "example": "examples",


### PR DESCRIPTION
When svgedit is used as a package (`npm i svgedit`), bundlers fail to resolve `import Editor from 'svgedit'` due to a wrong path in `main` property of package.json file.
