### PR TITLE
Make SvgCanvas class accessible from bundle

### DIFF
--- a/packages/svgcanvas/svgcanvas.js
+++ b/packages/svgcanvas/svgcanvas.js
@@ -1291,6 +1291,7 @@ class SvgCanvas {
     this.hasMatrixTransform = hasMatrixTransform
     this.transformListToTransform = transformListToTransform
     this.convertToNum = convertToNum
+    this.convertUnit = convertUnit
     this.findDefs = findDefs
     this.getUrlFromAttr = getUrlFromAttr
     this.getHref = getHref

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1415,3 +1415,4 @@ class Editor extends EditorStartup {
 }
 
 export default Editor
+export { SvgCanvas }


### PR DESCRIPTION
I'm using the bundle version of svgedit (as a package `npm i svgedit`), and I wanna use `convertUnit` utility which was defined in the module [packages/svgcanvas/core/units.js](https://github.com/SVG-Edit/svgedit/blob/04ab3dd8736fcac64980c88fee200c0e7b0bab10/packages/svgcanvas/core/units.js#L139) and [attached](https://github.com/SVG-Edit/svgedit/blob/04ab3dd8736fcac64980c88fee200c0e7b0bab10/packages/svgcanvas/svgcanvas.js#L1365) to SvgCanvas class so I thought it should be used as below:

```
import SvgCanvas from '@svgedit/svgcanvas';
SvgCanvas.convertUnit(38, 'cm');
```

but the following error arised:

![image](https://github.com/SVG-Edit/svgedit/assets/11967822/a0202611-ab2b-456b-b130-8fd395f9c68b)


`getRoundDigits` (or even `getBaseUnit` if I just call `SvgCanvas.convertUnit(38)`) is a method of SvgCanvas **instance** created by EditorStartup during [initialization](https://github.com/SVG-Edit/svgedit/blob/04ab3dd8736fcac64980c88fee200c0e7b0bab10/src/editor/EditorStartup.js#L116) and consequently [injected](https://github.com/SVG-Edit/svgedit/blob/04ab3dd8736fcac64980c88fee200c0e7b0bab10/packages/svgcanvas/svgcanvas.js#L121) to the module `units.js`.

The problem is that the instance of `SvgCanvas` is actually in the bundle, not in `@svgedit/svgcanvas`. 

I fixed this issue in a simple way, just re-exporting `SvgCanvas` from Editor.js as show in this pull request but there could be other ways.


