### PR TITLE
Add convertUnit utility function to SvgCanvas instance

### DIFF
--- a/packages/svgcanvas/svgcanvas.js
+++ b/packages/svgcanvas/svgcanvas.js
@@ -1291,6 +1291,7 @@ class SvgCanvas {
     this.hasMatrixTransform = hasMatrixTransform
     this.transformListToTransform = transformListToTransform
     this.convertToNum = convertToNum
+    this.convertUnit = convertUnit
     this.findDefs = findDefs
     this.getUrlFromAttr = getUrlFromAttr
     this.getHref = getHref


### PR DESCRIPTION
I'm using the bundle version of svgedit (as a package `npm i svgedit`) and  I wanna have access to `convertUnit` utitlity function in the same way I do with the opposite operation `convertToNum`.

This work:
```
import Editor from 'svgedit';
const svgEditor = new Editor(...);
svgEditor.svgCanvas.convertToNum('', '2cm');
```

This doesn't work:
```
svgEditor.svgCanvas.convertUnit(38, 'cm');`
```

![image](https://github.com/SVG-Edit/svgedit/assets/11967822/4fd18cb5-3609-49cd-be7d-400ca7af999f)
