### PR TITLE
Populate layers after new file is opened

### DIFF
--- a/src/editor/extensions/ext-opensave/ext-opensave.js
+++ b/src/editor/extensions/ext-opensave/ext-opensave.js
@@ -165,6 +165,7 @@ export default {
           size: blob.size,
           type: blob.type
         })
+        svgEditor.layersPanel.populateLayers()
       } catch (err) {
         if (err.name !== 'AbortError') {
           return console.error(err)


### PR DESCRIPTION
## PR description
With this fix the layers panel is updated when a new file is opened. Earlier, when an SVG file was opened the Layers panel was not populated with the correct number of layers and instead only showed 'Layer 1' irrespective of how many layers the newly opened file contained. This is fixed with a single-line change within the 'opensave' extension. 


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.
