### PR TITLE
Se spin input closed shadow

### DIFF
--- a/src/editor/components/seMenu.js
+++ b/src/editor/components/seMenu.js
@@ -70,6 +70,7 @@ export class SeMenu extends HTMLElement {
         image.src = this.imgPath + '/' + newValue
         image.width = 24
         image.height = 24
+        image.alt="logo";
         this.$label.prepend(image)
         break
       case 'label':

--- a/src/editor/components/seMenu.js
+++ b/src/editor/components/seMenu.js
@@ -70,7 +70,7 @@ export class SeMenu extends HTMLElement {
         image.src = this.imgPath + '/' + newValue
         image.width = 24
         image.height = 24
-        image.alt="logo";
+        image.alt = 'logo'
         this.$label.prepend(image)
         break
       case 'label':

--- a/src/editor/components/sePalette.js
+++ b/src/editor/components/sePalette.js
@@ -153,8 +153,8 @@ export class SEPalette extends HTMLElement {
           'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgY2xhc3M9InN2Z19pY29uIj48c3ZnIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgICA8bGluZSBmaWxsPSJub25lIiBzdHJva2U9IiNkNDAwMDAiIGlkPSJzdmdfOTAiIHkyPSIyNCIgeDI9IjI0IiB5MT0iMCIgeDE9IjAiLz4KICAgIDxsaW5lIGlkPSJzdmdfOTIiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2Q0MDAwMCIgeTI9IjI0IiB4Mj0iMCIgeTE9IjAiIHgxPSIyNCIvPgogIDwvc3ZnPjwvc3ZnPg=='
         img.style.width = '15px'
         img.style.height = '15px'
-        
-        img.alt="No color";
+
+        img.alt = 'No color'
 
         newDiv.append(img)
       } else {

--- a/src/editor/components/sePalette.js
+++ b/src/editor/components/sePalette.js
@@ -153,6 +153,9 @@ export class SEPalette extends HTMLElement {
           'data:image/svg+xml;charset=utf-8;base64,PHN2ZyB2aWV3Qm94PSIwIDAgMjQgMjQiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgd2lkdGg9IjI0IiBoZWlnaHQ9IjI0IiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayIgY2xhc3M9InN2Z19pY29uIj48c3ZnIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNCAyNCI+CiAgICA8bGluZSBmaWxsPSJub25lIiBzdHJva2U9IiNkNDAwMDAiIGlkPSJzdmdfOTAiIHkyPSIyNCIgeDI9IjI0IiB5MT0iMCIgeDE9IjAiLz4KICAgIDxsaW5lIGlkPSJzdmdfOTIiIGZpbGw9Im5vbmUiIHN0cm9rZT0iI2Q0MDAwMCIgeTI9IjI0IiB4Mj0iMCIgeTE9IjAiIHgxPSIyNCIvPgogIDwvc3ZnPjwvc3ZnPg=='
         img.style.width = '15px'
         img.style.height = '15px'
+        
+        img.alt="No color";
+
         newDiv.append(img)
       } else {
         newDiv.style.backgroundColor = rgb

--- a/src/editor/components/seSpinInput.js
+++ b/src/editor/components/seSpinInput.js
@@ -61,12 +61,12 @@ export class SESpinInput extends HTMLElement {
   constructor () {
     super()
     // create the shadowDom and insert the template
-    this._shadowRoot = this.attachShadow({ mode: 'open' })
+    this._shadowRoot = this.attachShadow({ mode: 'closed' })
     this._shadowRoot.append(template.content.cloneNode(true))
     // locate the component
     this.$div = this._shadowRoot.querySelector('div')
     this.$img = this._shadowRoot.querySelector('img')
-    this.$label = this.shadowRoot.getElementById('label')
+    this.$label = this._shadowRoot.getElementById('label')
     this.$event = new CustomEvent('change')
     this.$input = this._shadowRoot.querySelector('elix-number-spin-box')
     this.imgPath = svgEditor.configObj.curConfig.imgPath

--- a/src/editor/components/seZoom.js
+++ b/src/editor/components/seZoom.js
@@ -99,7 +99,7 @@ template.innerHTML = `
       <div id="arrow-down">▼</div>
     </div>
     <div id="down">
-      <img width="16" height="8" src="arrow_down.svg"/>
+      <img width="16" height="8" src="arrow_down.svg" alt="Zoom dropdown"/>
     </div>
   </div>
   <div id="options-container" style="display:none">


### PR DESCRIPTION
## PR description

Chrome and Edge browsers reported an issue with elements having duplicate `label` ids. This was caused by the `SESpinInput` having an "open" shadow DOM.  Closing the shadow DOM fixed this issue but caused another issue which was caused by the closed `shadowRoot` being undefined when accessing the label. Fixing this was accomplished by using `this._shadowRoot` instead of `this.shadowRoot`.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Fixes an issue in Chrome and Edge browsers related to duplicate label IDs caused by the `SESpinInput` component's open shadow DOM. The shadow DOM is now closed, and the component is updated to access the label using `this._shadowRoot` instead of `this.shadowRoot`. Also adds alt text to images in `SEPalette`, `SeZoom`, and `SeMenu` components.

Bug Fixes:
- Fixes an issue with elements having duplicate `label` ids in Chrome and Edge browsers by closing the shadow DOM in the `SESpinInput` component and updating the component to access the label using `this._shadowRoot`.

Enhancements:
- Adds alt text to images in `SEPalette`, `SeZoom`, and `SeMenu` components.