### PR TITLE
Fixed bug in ext-opensave.js when dropping text.

### DIFF
--- a/src/editor/extensions/ext-opensave/ext-opensave.js
+++ b/src/editor/extensions/ext-opensave/ext-opensave.js
@@ -44,9 +44,8 @@ export default {
     * @returns {void}
     */
     const importImage = (e) => {
-
       // only import files
-      if (!e.dataTransfer.types.includes("Files")) return;
+      if (!e.dataTransfer.types.includes('Files')) return
 
       $id('se-prompt-dialog').title = this.i18next.t('notification.loadingImage')
       $id('se-prompt-dialog').setAttribute('close', false)

--- a/src/editor/extensions/ext-opensave/ext-opensave.js
+++ b/src/editor/extensions/ext-opensave/ext-opensave.js
@@ -44,6 +44,10 @@ export default {
     * @returns {void}
     */
     const importImage = (e) => {
+
+      // only import files
+      if (!e.dataTransfer.types.includes("Files")) return;
+
       $id('se-prompt-dialog').title = this.i18next.t('notification.loadingImage')
       $id('se-prompt-dialog').setAttribute('close', false)
       e.stopPropagation()


### PR DESCRIPTION
## PR description

Fixed a bug in the ext-opensave.js which was only expecting file drops, but if you drag and drop text from another source (not a Files types, it puts SVGEdit into state where it says it is loading an image.

This code change just checks to insure that the data transfer types includes "Files".

This fix will allow other extensions to work with drag and drop from other non-file sources.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Bug Fixes:
- Fixes a bug where dragging and dropping text into SVGEdit would cause it to enter a state where it says it is loading an image.