### PR TITLE
Fixed bug in Editor.loadFromURL where the promise was not resolving

### DIFF
--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1353,7 +1353,7 @@ class Editor extends EditorStartup {
           })
           .then((str) => {
             this.loadSvgString(str, { noAlert })
-            return str
+            resolve(str);
           })
           .catch((error) => {
             if (noAlert) {

--- a/src/editor/Editor.js
+++ b/src/editor/Editor.js
@@ -1353,7 +1353,7 @@ class Editor extends EditorStartup {
           })
           .then((str) => {
             this.loadSvgString(str, { noAlert })
-            resolve(str);
+            resolve(str)
           })
           .catch((error) => {
             if (noAlert) {


### PR DESCRIPTION
## PR description

on successful load the Editor.loadFromURL() function returns the string, instead of resolving the string in the promise.
The result of this bug is that the function never returns.  This bug fixes that.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [X] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Fixes a bug where the Editor.loadFromURL() function was not resolving the promise on successful load, causing the function to never return. The fix ensures that the promise resolves with the loaded string.

Bug Fixes:
- Fixes a bug where the Editor.loadFromURL() function was not resolving the promise on successful load.

Tests:
- Adds Cypress UI tests to ensure the fix is not regressed in the future.