### PR TITLE
Html elements in foreign object

### DIFF
--- a/packages/svgcanvas/core/sanitize.js
+++ b/packages/svgcanvas/core/sanitize.js
@@ -93,7 +93,21 @@ const svgWhiteList_ = {
   munder: [],
   munderover: [],
   none: [],
-  semantics: []
+  semantics: [],
+
+  // HTML Elements for use in a foreignObject
+  DIV: [],
+  div: [],
+  P: [],
+  p: [],
+  LI: [],
+  li: [],
+  PRE: [],
+  pre: [],
+  OL: [],
+  ol: [],
+  UL: [],
+  ul: []
 }
 /* eslint-enable max-len */
 

--- a/packages/svgcanvas/core/sanitize.js
+++ b/packages/svgcanvas/core/sanitize.js
@@ -96,18 +96,21 @@ const svgWhiteList_ = {
   semantics: [],
 
   // HTML Elements for use in a foreignObject
-  DIV: [],
   div: [],
-  P: [],
   p: [],
-  LI: [],
   li: [],
-  PRE: [],
   pre: [],
-  OL: [],
   ol: [],
-  UL: [],
-  ul: []
+  ul: [],
+  span: [],
+  hr: [],
+  br: [],
+  h1: [],
+  h2: [],
+  h3: [],
+  h4: [],
+  h5: [],
+  h6: []
 }
 /* eslint-enable max-len */
 


### PR DESCRIPTION
## PR description

Added HTML elements to the sanitize whitelist:
`div, p, li, pre, ol, ul, span, hr, br, h1, h2, h3, h4, h5, h6
`
This will allow HTML elements in the foreignObject, enabling more text formatting capabilities that are allowed in SVG.

## Example SVG with elements
![HTML Elements](https://github.com/user-attachments/assets/e7020b7d-70d8-41ec-be32-b88960f37855)

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Extend the SVG sanitization whitelist to support additional HTML elements in foreignObject

New Features:
- Add support for HTML elements (div, p, li, pre, ol, ul, span, hr, br, h1-h6) within SVG foreignObject to enable more text formatting capabilities

Enhancements:
- Expand the sanitization whitelist to allow more flexible text rendering in SVG