### PR TITLE
fix the order of config() and init() in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,6 @@ V7 is changing significantly the way to integrate and customize SVGEdit. You can
   import Editor from './Editor.js'
   /* for available options see the file `docs/tutorials/ConfigOptions.md` */
   const svgEditor = new Editor(document.getElementById('container'))
-  /* initialize the Editor */
-  svgEditor.init()
   /* set the configuration */
   svgEditor.setConfig({
           allowInitialUserOverride: true,
@@ -98,19 +96,21 @@ V7 is changing significantly the way to integrate and customize SVGEdit. You can
           noDefaultExtensions: false,
           userExtensions: []
   })
+  /* initialize the Editor */
+  svgEditor.init()
 </script>
 </html>
 ```
 
 ## I want to build my own svg editor
 You can just use the underlying canvas and use it in your application with your favorite framework.
-See example in the demos folder or the svg-edit-react repository. 
+See example in the demos folder or the svg-edit-react repository.
 
 To install the canvas:
 
 `npm i -s '@svgedit/svgcanvas'`
 
-you can then import it in your application: 
+you can then import it in your application:
 
 `import svgCanvas from '@svgedit/svgcanvas'`
 


### PR DESCRIPTION
This helps newcomers who copy‑paste the example end up wondering why their custom options/extensions not take effect.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [x] - Added Cypress UI tests
- [x] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [x] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Correct the order of configuration and initialization in the README example to ensure custom options and extensions are applied correctly

Bug Fixes:
- Reorder the `setConfig()` and `init()` method calls in the code example to allow proper configuration of the SVG Editor before initialization

Documentation:
- Update the README code example to demonstrate the correct sequence of configuring and initializing the SVG Editor