### PR TITLE
Fixed issue where svgToString was converting HTML elements to upperca…

### DIFF
--- a/packages/svgcanvas/core/svg-exec.js
+++ b/packages/svgcanvas/core/svg-exec.js
@@ -144,7 +144,7 @@ const svgToString = (elem, indent) => {
       out.push(' ')
     }
     out.push('<')
-    out.push(elem.nodeName)
+    out.push(elem.localName)
     if (elem.id === 'svgcontent') {
       // Process root element separately
       const res = svgCanvas.getResolution()
@@ -352,7 +352,7 @@ const svgToString = (elem, indent) => {
         }
       }
       out.push('</')
-      out.push(elem.nodeName)
+      out.push(elem.localName)
       out.push('>')
     } else {
       out.push('/>')


### PR DESCRIPTION
…se in svgCanvas.svgToString()

## PR description

svgCanvas.svgToString was using nodeName in XML generation which was generating UPPERCASE XHTML elements.  replacing with localName fixes this.


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Bug Fixes:
- Corrected svgToString method to use localName, preventing uppercase element names in XML generation