### PR TITLE
Fixed issue where foreignObject contents styles were getting removed on object moving

### DIFF
--- a/packages/svgcanvas/core/event.js
+++ b/packages/svgcanvas/core/event.js
@@ -662,9 +662,18 @@ const mouseUpEvent = (evt) => {
         const elem = selectedElements[0]
         if (elem) {
           elem.removeAttribute('style')
-          walkTree(elem, (el) => {
-            el.removeAttribute('style')
-          })
+
+          // we don't remove the style elements for contents of foreignObjects
+          // because that is a valid way to style them
+          if (elem.localName === 'foreignObject') {
+            walkTree(elem, (el) => {
+              el.style.removeProperty('pointer-events')
+            })
+          } else {
+            walkTree(elem, (el) => {
+              el.removeAttribute('style')
+            })
+          }
         }
       }
       return


### PR DESCRIPTION
## PR description

when moving foreignObject elements, the styles in the contents were getting removed.  This fixes that issue so that style attributes in the contents of foreignObjects do not get removed on a move.


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Preserve styles for foreignObject contents when moving SVG elements

Bug Fixes:
- Fixed an issue where styles were being removed from foreignObject contents during element movement

Enhancements:
- Added special handling for foreignObject elements to preserve their internal styles