### PR TITLE
Fixed a bug where a rotated text or image did not translate correctly.

### DIFF
--- a/packages/svgcanvas/core/recalculate.js
+++ b/packages/svgcanvas/core/recalculate.js
@@ -245,8 +245,9 @@ export const recalculateDimensions = selected => {
         const cx = xAttr + width / 2
         const cy = yAttr + height / 2
         oldcenter = { x: cx, y: cy }
-        newcenter = transformPoint(cx, cy, transformListToTransform(tlist).matrix)
-      } else if (selected.localName=='text') {
+        const transform = transformListToTransform(tlist).matrix
+        newcenter = transformPoint(cx, cy, transform)
+      } else if (selected.localName === 'text') {
         // Use the center of the bounding box as the rotation center for text
         const cx = box.x + box.width / 2
         const cy = box.y + box.height / 2


### PR DESCRIPTION
## PR description

Fixed bug #1048  where a rotated text or image did not translate correctly.

## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [X] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Fix incorrect translation of rotated SVG images and text by computing element-specific rotation centers.

Bug Fixes:
- Compute rotation center for images using their x/y attributes and dimensions to ensure correct translation after rotation
- Compute rotation center for text using its bounding box center to ensure correct translation after rotation

Enhancements:
- Refactor rotation center calculation to handle images, text, and other elements with appropriate fallbacks