### PR TITLE
Fix group rotation

### DIFF
--- a/packages/svgcanvas/core/history.js
+++ b/packages/svgcanvas/core/history.js
@@ -423,14 +423,14 @@ export class BatchCommand extends Command {
   * @fires module:history~Command#event:history
   * @returns {void}
   */
-  unapply (handler) {
-    super.unapply(handler, () => {
-      this.stack.reverse().forEach((stackItem) => {
-        console.assert(stackItem, 'stack item should not be null')
-        stackItem && stackItem.unapply(handler)
-      })
+  unapply(handler) {
+  super.unapply(handler, () => {
+    [...this.stack].reverse().forEach((stackItem) => {
+      console.assert(stackItem, 'stack item should not be null')
+      stackItem && stackItem.unapply(handler)
     })
-  }
+  })
+}
 
   /**
   * Iterate through all our subcommands.

--- a/packages/svgcanvas/core/history.js
+++ b/packages/svgcanvas/core/history.js
@@ -423,14 +423,14 @@ export class BatchCommand extends Command {
   * @fires module:history~Command#event:history
   * @returns {void}
   */
-  unapply(handler) {
-  super.unapply(handler, () => {
-    [...this.stack].reverse().forEach((stackItem) => {
-      console.assert(stackItem, 'stack item should not be null')
-      stackItem && stackItem.unapply(handler)
+  unapply (handler) {
+    super.unapply(handler, () => {
+      [...this.stack].reverse().forEach((stackItem) => {
+        console.assert(stackItem, 'stack item should not be null')
+        stackItem && stackItem.unapply(handler)
+      })
     })
-  })
-}
+  }
 
   /**
   * Iterate through all our subcommands.


### PR DESCRIPTION
## Problem

Undo/redo history may break after grouping elements and performing several undo/redo operations, due to in-place mutation of the command stack in `BatchCommand` (uses `reverse()`).

## Solution

- Change `BatchCommand.unapply` to use `[...this.commands].reverse()` so the original array is never mutated.
- This preserves the order of commands and ensures history integrity.

## Testing

- Group elements, perform undo/redo, and ensure undo/redo works as expected.
- No exceptions such as `NotFoundError` should occur during these operations.

## Related Issue

Fixes #1039

## Summary by Sourcery

Bug Fixes:
- Clone the command stack before reversing in BatchCommand.unapply to preserve history integrity and prevent errors during undo/redo.