### PR TITLE
fix(svgcanvas): Handle 'none' stroke color in SVG elements

### DIFF
--- a/packages/svgcanvas/svgcanvas.js
+++ b/packages/svgcanvas/svgcanvas.js
@@ -201,7 +201,9 @@ class SvgCanvas {
           this.curConfig.initFill.color,
         fill_paint: null,
         fill_opacity: this.curConfig.initFill.opacity,
-        stroke: `#${this.curConfig.initStroke.color}`,
+        stroke:
+          (this.curConfig.initStroke.color === 'none' ? '' : '#') +
+          this.curConfig.initStroke.color,
         stroke_paint: null,
         stroke_opacity: this.curConfig.initStroke.opacity,
         stroke_width: this.curConfig.initStroke.width,

--- a/src/editor/extensions/ext-connector/ext-connector.js
+++ b/src/editor/extensions/ext-connector/ext-connector.js
@@ -447,7 +447,10 @@ export default {
               attr: {
                 id: 'conn_' + svgCanvas.getNextId(),
                 points: `${x},${y} ${x},${y} ${startX},${startY}`,
-                stroke: `#${initStroke.color}`,
+                stroke:
+                  initStroke.color === 'none'
+                    ? 'none'
+                    : `#${initStroke.color}`,
                 'stroke-width':
                   !startElem.stroke_width || startElem.stroke_width === 0
                     ? initStroke.width


### PR DESCRIPTION
This update modifies the stroke color handling in both the SvgCanvas and ext-connector modules. When the stroke color is set to 'none', it now correctly assigns an empty string or 'none' instead of a hex value, ensuring proper rendering of SVG elements without strokes.

## PR description

<!-- Add the description of your PR here -->


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Handle SVG stroke color set to 'none' without converting it to a hex value, ensuring connectors and newly created elements render correctly without strokes.

Bug Fixes:
- Ensure connectors created by the ext-connector extension preserve a 'none' stroke value instead of forcing a hex color.
- Prevent SvgCanvas from prefixing a hex marker when the initial stroke color is 'none', allowing elements to have no stroke as intended.