### PR TITLE
feat(svgcanvas): Trigger 'changed' event on text attribute modifications

### DIFF
--- a/packages/svgcanvas/core/elem-get-set.js
+++ b/packages/svgcanvas/core/elem-get-set.js
@@ -679,6 +679,7 @@ const setBoldMethod = (b) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -768,6 +769,7 @@ const setItalicMethod = (i) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -779,6 +781,7 @@ const setTextAnchorMethod = (value) => {
   const selectedElements = svgCanvas.getSelectedElements()
   const textElements = selectedElements.filter(el => el?.tagName === 'text')
   svgCanvas.changeSelectedAttribute('text-anchor', value, textElements)
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -793,6 +796,7 @@ const setLetterSpacingMethod = (value) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -807,6 +811,7 @@ const setWordSpacingMethod = (value) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -821,6 +826,7 @@ const setTextLengthMethod = (value) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -835,6 +841,7 @@ const setLengthAdjustMethod = (value) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -859,6 +866,7 @@ const setFontFamilyMethod = (val) => {
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -868,8 +876,10 @@ const setFontFamilyMethod = (val) => {
 * @returns {void}
 */
 const setFontColorMethod = (val) => {
+  const selectedElements = svgCanvas.getSelectedElements()
   svgCanvas.setCurText('fill', val)
   svgCanvas.changeSelectedAttribute('fill', val)
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**
@@ -901,6 +911,7 @@ const setFontSizeMethod = (val) => {
   if (!selectedElements[0]?.textContent) {
     svgCanvas.textActions.setCursor()
   }
+  svgCanvas.call('changed', selectedElements)
 }
 
 /**

--- a/packages/svgcanvas/core/elem-get-set.js
+++ b/packages/svgcanvas/core/elem-get-set.js
@@ -655,14 +655,31 @@ const setStrokeAttrMethod = (attr, val) => {
   }
 }
 
+const getSelectedTextElements = () => {
+  return svgCanvas.getSelectedElements().filter(el => el?.tagName === 'text')
+}
+
+const getChangedTextElements = (textElements, attr, newValue) => {
+  const normalizedValue = String(newValue)
+  return textElements.filter((elem) => {
+    const oldValue = attr === '#text' ? elem.textContent : elem.getAttribute(attr)
+    return (oldValue || '') !== normalizedValue
+  })
+}
+
+const notifyTextChange = (textElements) => {
+  if (textElements.length > 0) {
+    svgCanvas.call('changed', textElements)
+  }
+}
+
 /**
  * Check if all selected text elements are in bold.
  * @function module:svgcanvas.SvgCanvas#getBold
  * @returns {boolean} `true` if all selected elements are bold, `false` otherwise.
  */
 const getBoldMethod = () => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
   return textElements.every(el => el.getAttribute('font-weight') === 'bold')
 }
 
@@ -673,13 +690,16 @@ const getBoldMethod = () => {
  * @returns {void}
  */
 const setBoldMethod = (b) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('font-weight', b ? 'bold' : 'normal', textElements)
+  const textElements = getSelectedTextElements()
+  const value = b ? 'bold' : 'normal'
+  const changedTextElements = getChangedTextElements(textElements, 'font-weight', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('font-weight', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -687,8 +707,7 @@ const setBoldMethod = (b) => {
  * @returns {boolean} Indicates whether or not elements have the text decoration value
  */
 const hasTextDecorationMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
   return textElements.every(el => (el.getAttribute('text-decoration') || '').includes(value))
 }
 
@@ -699,8 +718,7 @@ const hasTextDecorationMethod = (value) => {
  */
 const addTextDecorationMethod = (value) => {
   const { ChangeElementCommand, BatchCommand } = svgCanvas.history
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
 
   const batchCmd = new BatchCommand()
   textElements.forEach(elem => {
@@ -727,8 +745,7 @@ const addTextDecorationMethod = (value) => {
  */
 const removeTextDecorationMethod = (value) => {
   const { ChangeElementCommand, BatchCommand } = svgCanvas.history
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
 
   const batchCmd = new BatchCommand()
   textElements.forEach(elem => {
@@ -751,8 +768,7 @@ const removeTextDecorationMethod = (value) => {
  * @returns {boolean} `true` if all selected elements are in italics, `false` otherwise.
  */
 const getItalicMethod = () => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
   return textElements.every(el => el.getAttribute('font-style') === 'italic')
 }
 
@@ -763,13 +779,16 @@ const getItalicMethod = () => {
  * @returns {void}
  */
 const setItalicMethod = (i) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('font-style', i ? 'italic' : 'normal', textElements)
+  const textElements = getSelectedTextElements()
+  const value = i ? 'italic' : 'normal'
+  const changedTextElements = getChangedTextElements(textElements, 'font-style', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('font-style', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -778,10 +797,12 @@ const setItalicMethod = (i) => {
  * @returns {void}
  */
 const setTextAnchorMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('text-anchor', value, textElements)
-  svgCanvas.call('changed', selectedElements)
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'text-anchor', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('text-anchor', value, changedTextElements)
+  }
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -790,13 +811,15 @@ const setTextAnchorMethod = (value) => {
  * @returns {void}
  */
 const setLetterSpacingMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('letter-spacing', value, textElements)
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'letter-spacing', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('letter-spacing', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -805,13 +828,15 @@ const setLetterSpacingMethod = (value) => {
  * @returns {void}
  */
 const setWordSpacingMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('word-spacing', value, textElements)
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'word-spacing', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('word-spacing', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -820,13 +845,15 @@ const setWordSpacingMethod = (value) => {
  * @returns {void}
  */
 const setTextLengthMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('textLength', value, textElements)
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'textLength', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('textLength', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -835,13 +862,15 @@ const setTextLengthMethod = (value) => {
  * @returns {void}
  */
 const setLengthAdjustMethod = (value) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
-  svgCanvas.changeSelectedAttribute('lengthAdjust', value, textElements)
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'lengthAdjust', value)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('lengthAdjust', value, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -859,14 +888,16 @@ const getFontFamilyMethod = () => {
 * @returns {void}
 */
 const setFontFamilyMethod = (val) => {
-  const selectedElements = svgCanvas.getSelectedElements()
-  const textElements = selectedElements.filter(el => el?.tagName === 'text')
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'font-family', val)
   svgCanvas.setCurText('font_family', val)
-  svgCanvas.changeSelectedAttribute('font-family', val, textElements)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('font-family', val, changedTextElements)
+  }
   if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -876,10 +907,13 @@ const setFontFamilyMethod = (val) => {
 * @returns {void}
 */
 const setFontColorMethod = (val) => {
-  const selectedElements = svgCanvas.getSelectedElements()
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'fill', val)
   svgCanvas.setCurText('fill', val)
-  svgCanvas.changeSelectedAttribute('fill', val)
-  svgCanvas.call('changed', selectedElements)
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('fill', val, changedTextElements)
+  }
+  notifyTextChange(changedTextElements)
 }
 
 /**
@@ -905,13 +939,16 @@ const getFontSizeMethod = () => {
 * @returns {void}
 */
 const setFontSizeMethod = (val) => {
-  const selectedElements = svgCanvas.getSelectedElements()
+  const textElements = getSelectedTextElements()
+  const changedTextElements = getChangedTextElements(textElements, 'font-size', val)
   svgCanvas.setCurText('font_size', val)
-  svgCanvas.changeSelectedAttribute('font-size', val)
-  if (!selectedElements[0]?.textContent) {
+  if (changedTextElements.length > 0) {
+    svgCanvas.changeSelectedAttribute('font-size', val, changedTextElements)
+  }
+  if (!textElements.some(el => el.textContent)) {
     svgCanvas.textActions.setCursor()
   }
-  svgCanvas.call('changed', selectedElements)
+  notifyTextChange(changedTextElements)
 }
 
 /**

--- a/tests/unit/elem-get-set.test.js
+++ b/tests/unit/elem-get-set.test.js
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, describe, expect, it } from 'vitest'
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest'
 import { NS } from '../../packages/svgcanvas/core/namespaces.js'
 import * as history from '../../packages/svgcanvas/core/history.js'
 import dataStorage from '../../packages/svgcanvas/core/dataStorage.js'
@@ -35,7 +35,8 @@ describe('elem-get-set', () => {
         clear () {}
       },
       runExtensions () {},
-      call () {},
+      call: vi.fn(),
+      changeSelectedAttribute: vi.fn(),
       getDOMDocument () { return document },
       getSvgContent () { return svgContent },
       getSelectedElements () { return this.selectedElements || [] },
@@ -51,6 +52,10 @@ describe('elem-get-set', () => {
       },
       addCommandToHistory (cmd) {
         historyStack.push(cmd)
+      },
+      setCurText () {},
+      textActions: {
+        setCursor () {}
       }
     }
     svgContent.setAttribute('width', '100')
@@ -231,5 +236,44 @@ describe('elem-get-set', () => {
     localCanvas.undoMgr.redo()
     expect(localCanvas.contentW).toBe(200)
     expect(localCanvas.contentH).toBe(150)
+  })
+
+  it('setBold() emits changed only for modified text elements', () => {
+    const text = createSvgElement('text')
+    text.textContent = 'Hello'
+    const rect = createSvgElement('rect')
+    svgContent.append(text, rect)
+    canvas.selectedElements = [text, rect]
+
+    canvas.setBold(true)
+
+    expect(canvas.changeSelectedAttribute).toHaveBeenCalledWith('font-weight', 'bold', [text])
+    expect(canvas.call).toHaveBeenCalledWith('changed', [text])
+  })
+
+  it('setBold() skips changed event for no-op text updates', () => {
+    const text = createSvgElement('text')
+    text.textContent = 'Hello'
+    text.setAttribute('font-weight', 'bold')
+    svgContent.append(text)
+    canvas.selectedElements = [text]
+
+    canvas.setBold(true)
+
+    expect(canvas.changeSelectedAttribute).not.toHaveBeenCalled()
+    expect(canvas.call).not.toHaveBeenCalled()
+  })
+
+  it('setFontColor() ignores non-text selections when emitting changed', () => {
+    const text = createSvgElement('text')
+    text.textContent = 'Hello'
+    const rect = createSvgElement('rect')
+    svgContent.append(text, rect)
+    canvas.selectedElements = [text, rect]
+
+    canvas.setFontColor('#f00')
+
+    expect(canvas.changeSelectedAttribute).toHaveBeenCalledWith('fill', '#f00', [text])
+    expect(canvas.call).toHaveBeenCalledWith('changed', [text])
   })
 })


### PR DESCRIPTION
This update adds a call to the 'changed' event for various text attribute methods, ensuring that changes to text elements are properly tracked and reflected in the SVG canvas. The methods updated include setBold, setItalic, setTextAnchor, setLetterSpacing, setWordSpacing, setTextLength, setLengthAdjust, setFontFamily, setFontColor, and setFontSize.

## PR description

<!-- Add the description of your PR here -->


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Ensure text formatting updates on SVG text elements trigger canvas change notifications.

Bug Fixes:
- Trigger the global 'changed' event after modifying text attributes so text edits are consistently tracked and reflected in the canvas state.

Enhancements:
- Standardize text attribute setters (bold, italic, spacing, anchor, font properties) to notify listeners after applying changes.