### PR TITLE
Fix three bugs: font-size units, imported-SVG ungroup, duplicate jPicker dialogs

### DIFF
--- a/packages/svgcanvas/core/selected-elem.js
+++ b/packages/svgcanvas/core/selected-elem.js
@@ -1069,6 +1069,7 @@ const convertToGroup = elem => {
     tlist.appendItem(xform)
     recalculateDimensions(elem)
     svgCanvas.call('selected', [elem])
+    return elem
   } else if (dataStorage.has($elem, 'symbol')) {
     elem = dataStorage.get($elem, 'symbol')
     if (!elem) {
@@ -1203,8 +1204,10 @@ const convertToGroup = elem => {
     }
 
     svgCanvas.addCommandToHistory(batchCmd)
+    return g
   } else {
     warn('Unexpected element to ungroup:', elem, 'selected-elem')
+    return null
   }
 }
 
@@ -1222,11 +1225,14 @@ const ungroupSelectedElement = () => {
     return
   }
   if (dataStorage.has(g, 'gsvg') || dataStorage.has(g, 'symbol')) {
-    // Is svg, so actually convert to group
-    convertToGroup(g)
-    return
-  }
-  if (g.tagName === 'use') {
+    // Is svg (e.g. imported content), so convert to a real group first, then
+    // fall through below to actually ungroup/flatten that new group - a
+    // single Ungroup action on imported content should ungroup it, not just
+    // silently swap its <use>/gsvg wrapper for a <g> that still needs a
+    // second Ungroup to do anything.
+    g = convertToGroup(g)
+    if (!g) { return }
+  } else if (g.tagName === 'use') {
     // Somehow doesn't have data set, so retrieve
     const href = getHref(g)
     if (!href || !href.startsWith('#')) {
@@ -1240,8 +1246,8 @@ const ungroupSelectedElement = () => {
     }
     dataStorage.put(g, 'symbol', symbol)
     dataStorage.put(g, 'ref', symbol)
-    convertToGroup(g)
-    return
+    g = convertToGroup(g)
+    if (!g) { return }
   }
   const parentsA = getParents(g.parentNode, 'a')
   if (parentsA?.length) {

--- a/packages/svgcanvas/core/undo.js
+++ b/packages/svgcanvas/core/undo.js
@@ -205,7 +205,10 @@ export const changeSelectedAttributeNoUndoMethod = (attr, newValue, elems) => {
       } else if (attr === '#href') {
         setHref(elem, newValue)
       } else if (newValue) {
-        elem.setAttribute(attr, isNaN(parseFloat(newValue)) ? newValue : parseFloat(newValue))
+        // Number(), unlike parseFloat(), rejects a value with a trailing unit suffix
+        // (e.g. "10pt", "2px") instead of silently truncating it to a bare number.
+        const asNumber = Number(newValue)
+        elem.setAttribute(attr, Number.isNaN(asNumber) ? newValue : asNumber)
       } else if (typeof newValue === 'number') {
         elem.setAttribute(attr, newValue)
       } else {

--- a/src/editor/components/jgraduate/jQuery.jPicker.js
+++ b/src/editor/components/jgraduate/jQuery.jPicker.js
@@ -1408,6 +1408,11 @@ export function jPickerMethod (elem, options, commitCallback, liveCallback, canc
               : (poslt.top + Number.parseInt(win.position.y)) + 'px'
     } else {
       container = that
+      // Remove any table left behind by a previous invocation on this same
+      // persistent container instead of appending another one alongside it
+      // (this container is shown/hidden, not recreated, between opens).
+      const existingTable = container.querySelector('#jPicker-table')
+      if (existingTable) { existingTable.remove() }
       const newDiv = document.createElement('div')
       newDiv.innerHTML = controlHtml
       while (newDiv.children.length > 0) {

--- a/src/editor/panels/TopPanel.js
+++ b/src/editor/panels/TopPanel.js
@@ -418,7 +418,10 @@ class TopPanel {
         }
       }
       menuItems.setAttribute(
-        (tagName === 'g' ? 'en' : 'dis') + 'ablemenuitems',
+        // A <use> referencing a local <symbol> is how imported SVG content
+        // is represented, and is ungroupable just like a <g> (see
+        // ungroupSelectedElement()); it shouldn't be locked out of the menu.
+        (tagName === 'g' || tagName === 'use' ? 'en' : 'dis') + 'ablemenuitems',
         '#ungroup'
       )
       menuItems.setAttribute(

--- a/tests/unit/change-selected-attribute-units.test.js
+++ b/tests/unit/change-selected-attribute-units.test.js
@@ -1,0 +1,82 @@
+import SvgCanvas from '../../packages/svgcanvas/svgcanvas.js'
+
+// Regression test for https://github.com/SVG-Edit/svgedit/issues/949:
+// setting a unit-suffixed attribute value (e.g. font-size="10pt") must
+// preserve the unit instead of being silently truncated to a bare number.
+describe('Issue 949: changeSelectedAttribute preserves unit suffixes', function () {
+  let svgCanvas
+
+  beforeEach(() => {
+    document.body.textContent = ''
+    const svgEditor = document.createElement('div')
+    svgEditor.id = 'svg_editor'
+    const svgcanvas = document.createElement('div')
+    svgcanvas.style.visibility = 'hidden'
+    svgcanvas.id = 'svgcanvas'
+    const workarea = document.createElement('div')
+    workarea.id = 'workarea'
+    workarea.append(svgcanvas)
+    const toolsLeft = document.createElement('div')
+    toolsLeft.id = 'tools_left'
+
+    svgEditor.append(workarea, toolsLeft)
+    document.body.append(svgEditor)
+
+    svgCanvas = new SvgCanvas(
+      document.getElementById('svgcanvas'), {
+        canvas_expansion: 3,
+        dimensions: [640, 480],
+        initFill: { color: 'FF0000', opacity: 1 },
+        initStroke: { width: 5, color: '000000', opacity: 1 },
+        initOpacity: 1,
+        imgPath: '../editor/images',
+        langPath: 'locale/',
+        extPath: 'extensions/',
+        extensions: [],
+        initTool: 'select',
+        wireframe: false
+      }
+    )
+  })
+
+  it('keeps a "pt" unit suffix on font-size instead of truncating to a float', function () {
+    svgCanvas.setSvgString(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">' +
+        '<text id="t1" x="10" y="10" font-size="12">hi</text>' +
+      '</svg>'
+    )
+    const elem = document.getElementById('t1')
+
+    svgCanvas.changeSelectedAttribute('font-size', '10pt', [elem])
+
+    assert.equal(elem.getAttribute('font-size'), '10pt')
+  })
+
+  it('keeps other unit suffixes (px, em, %) intact', function () {
+    svgCanvas.setSvgString(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">' +
+        '<rect id="r1" x="10" y="10" width="20" height="20" stroke-width="1"/>' +
+      '</svg>'
+    )
+    const elem = document.getElementById('r1')
+
+    svgCanvas.changeSelectedAttribute('stroke-width', '2px', [elem])
+    assert.equal(elem.getAttribute('stroke-width'), '2px')
+
+    svgCanvas.changeSelectedAttribute('stroke-width', '1.5em', [elem])
+    assert.equal(elem.getAttribute('stroke-width'), '1.5em')
+  })
+
+  it('still converts a plain numeric string to a real number (issue #930)', function () {
+    svgCanvas.setSvgString(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="640" height="480">' +
+        '<g id="g1"><rect x="10" y="10" width="20" height="20"/></g>' +
+      '</svg>'
+    )
+    const elem = document.getElementById('g1')
+
+    svgCanvas.changeSelectedAttribute('rx', '10.5', [elem])
+
+    assert.equal(elem.getAttribute('rx'), '10.5')
+  })
+})

--- a/tests/unit/selected-elem.test.js
+++ b/tests/unit/selected-elem.test.js
@@ -122,7 +122,12 @@ describe('selected-elem', () => {
     expect(order).toEqual(['title', 'defs', 'rect-bottom-2', 'rect-bottom-1'])
   })
 
-  it('ungroups a <use> when it is the first element child', () => {
+  // Regression test for https://github.com/SVG-Edit/svgedit/issues/953:
+  // a single Ungroup action on imported SVG content (represented as a <use>
+  // referencing a local <symbol>, per importSvgString()) must fully unwrap
+  // it, not just silently convert the <use> into an equivalent <g> that
+  // still requires a second Ungroup to actually flatten.
+  it('fully ungroups a <use> (imported SVG content) in a single call', () => {
     const defs = svgCanvas.getSvgContent().querySelector('defs') ||
       svgCanvas.getSvgContent().appendChild(document.createElementNS(NS.SVG, 'defs'))
 
@@ -151,10 +156,10 @@ describe('selected-elem', () => {
     expect(() => svgCanvas.ungroupSelectedElement()).not.toThrow()
 
     expect(container.querySelector('use')).toBeNull()
-    const group = container.firstElementChild
-    expect(group).toBeTruthy()
-    expect(group.tagName).toBe('g')
-    expect(group.querySelector('rect')).toBeTruthy()
+    expect(container.querySelector('g')).toBeNull()
+    const rect = container.firstElementChild
+    expect(rect).toBeTruthy()
+    expect(rect.tagName).toBe('rect')
   })
 
   it('does not crash ungrouping a <use> without href', () => {


### PR DESCRIPTION
## Summary

- Fixes #949: unit-suffixed attribute values (e.g. `font-size="10pt"`, `stroke-width="2px"`) were silently truncated to a bare number, stripping the unit - a regression from #935.
- Fixes #953: ungrouping imported SVG content (a `<use>` referencing a `<symbol>`, per `importSvgString()`) took two separate Ungroup actions instead of one, and the right-click context menu's Ungroup entry was hard-disabled for `<use>` elements entirely.
- Fixes #957: repeatedly double-clicking a gradient stop's color swatch stacked duplicate `#jPicker-table` elements into the picker's container instead of replacing the previous one.

## Root causes & fixes

**#949** - `changeSelectedAttributeNoUndoMethod` (`packages/svgcanvas/core/undo.js`) used `isNaN(parseFloat(newValue))` to decide whether to store a parsed number or the raw string. `parseFloat` only parses the *leading* numeric portion of a string, so `"10pt"` parses to `10` without failing, silently dropping the unit. Switched to `Number(newValue)`, which returns `NaN` unless the *entire* string is numeric - correctly rejecting `"10pt"` while still converting a plain numeric string like `"10.5"` to a real number (preserving the fix #935 made for #930).

**#953** - `ungroupSelectedElement` (`packages/svgcanvas/core/selected-elem.js`) called `convertToGroup()` on a `<use>`/`gsvg`-tagged element and returned immediately, so a single Ungroup only swapped the wrapper for an equivalent `<g>` without ever flattening it. `convertToGroup()` now returns the group it produces, and `ungroupSelectedElement` reassigns its local `g` to that result and falls through to the existing flatten logic instead of returning early. Separately, `TopPanel.js`'s context-menu enable/disable logic only recognized `tagName === 'g'` as ungroupable, hard-disabling the menu item (via `pointer-events: none`) for the `<use>` that imported content actually is - now also enabled for `'use'`.

**#957** - `jQuery.jPicker.js`'s `initialize()` unconditionally appends a fresh `#jPicker-table` into its (persistent, shown/hidden-not-recreated) container on every open, with no check for a pre-existing one in the non-expandable branch used by the gradient stop-color picker. Added the same kind of cleanup already used for the toolbar fill/stroke swatch pickers (#1033), generalized to this container.

## Test plan

- [x] `npm run lint`
- [x] `npx vitest run tests/unit` - 567 tests pass, including a new regression test file for #949 (`tests/unit/change-selected-attribute-units.test.js`) and an updated test for #953 (`tests/unit/selected-elem.test.js`)
- [x] `npm test` (unit + all 81 e2e) - all pass
- [x] `npm run build` - production build succeeds
- [x] Manually verified #953 and #957 end-to-end in a real browser (Playwright driving the actual dev server): importing SVG content and clicking the real context-menu Ungroup entry now fully unwraps it into the layer in one action; repeatedly reopening the picker on the same container leaves exactly one `#jPicker-table` instead of stacking duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Fix attribute handling, ungrouping of imported SVG content, and gradient color picker behavior, and add regression coverage for these cases.

Bug Fixes:
- Preserve unit-suffixed attribute values like font-size="10pt" and stroke-width="2px" instead of truncating them to bare numbers.
- Ensure a single Ungroup action fully unwraps imported SVG content represented as <use>/<symbol> and enable Ungroup in the context menu for such elements.
- Prevent duplicate jPicker table elements from accumulating when reopening the gradient stop color picker.

Tests:
- Add a regression test suite to verify changeSelectedAttribute preserves unit suffixes while still converting plain numeric strings.
- Update ungroupSelectedElement tests to assert imported <use>-based content is fully flattened by a single ungroup operation.