### PR TITLE
Ability to rely on configuration stored in attributes. Expand SVG whitelist and do not trim text/tspan nodes, they may have xml:space="preserve"

### DIFF
--- a/packages/svgcanvas/core/sanitize.js
+++ b/packages/svgcanvas/core/sanitize.js
@@ -62,10 +62,10 @@ const svgWhiteList_ = {
   svg: ['clip-path', 'clip-rule', 'enable-background', 'filter', 'height', 'mask', 'preserveAspectRatio', 'requiredFeatures', 'systemLanguage', 'version', 'viewBox', 'width', 'x', 'xmlns', 'xmlns:se', 'xmlns:xlink', 'xmlns:oi', 'oi:animations', 'y', 'stroke-linejoin', 'fill-rule', 'aria-label', 'stroke-width', 'fill-rule', 'xml:space'],
   switch: ['requiredFeatures', 'systemLanguage'],
   symbol: [...FONT_ATTRIBUTES, 'fill', 'fill-opacity', 'fill-rule', 'filter', 'opacity', 'overflow', 'preserveAspectRatio', 'requiredFeatures', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'systemLanguage', 'viewBox', 'width', 'height'],
-  text: [...FONT_ATTRIBUTES, 'clip-path', 'clip-rule', 'dominant-baseline', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'mask', 'opacity', 'requiredFeatures', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'systemLanguage', 'text-anchor', 'letter-spacing', 'word-spacing', 'text-decoration', 'textLength', 'lengthAdjust', 'x', 'xml:space', 'y'],
+  text: [...FONT_ATTRIBUTES, 'clip-path', 'clip-rule', 'alignment-baseline', 'dominant-baseline', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'mask', 'opacity', 'requiredFeatures', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'systemLanguage', 'text-anchor', 'letter-spacing', 'word-spacing', 'text-decoration', 'textLength', 'lengthAdjust', 'x', 'xml:space', 'y'],
   textPath: ['dominant-baseline', 'href', 'method', 'requiredFeatures', 'spacing', 'startOffset', 'systemLanguage', 'xlink:href'],
   title: [],
-  tspan: [...FONT_ATTRIBUTES, 'clip-path', 'clip-rule', 'dx', 'dy', 'dominant-baseline', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'mask', 'opacity', 'requiredFeatures', 'rotate', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'systemLanguage', 'text-anchor', 'textLength', 'x', 'xml:space', 'y'],
+  tspan: [...FONT_ATTRIBUTES, 'clip-path', 'clip-rule', 'dx', 'dy', 'alignment-baseline', 'dominant-baseline', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'mask', 'opacity', 'requiredFeatures', 'rotate', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'systemLanguage', 'text-anchor', 'textLength', 'x', 'xml:space', 'y'],
   use: ['clip-path', 'clip-rule', 'fill', 'fill-opacity', 'fill-rule', 'filter', 'height', 'href', 'mask', 'stroke', 'stroke-dasharray', 'stroke-dashoffset', 'stroke-linecap', 'stroke-linejoin', 'stroke-miterlimit', 'stroke-opacity', 'stroke-width', 'width', 'x', 'xlink:href', 'y', 'overflow'],
   // Filter Primitives
   feComponentTransfer: ['in', 'result'],
@@ -162,7 +162,10 @@ export const sanitizeSvg = (node) => {
   // Cleanup text nodes
   if (node.nodeType === 3) { // 3 === TEXT_NODE
     // Trim whitespace
-    node.nodeValue = node.nodeValue.trim()
+    // Smartsys Ltd: Do not trim values of <text> tags, they may have xml:space="preserve" attribute".
+    if (node.parentElement?.nodeName !== 'text') {
+      node.nodeValue = node.nodeValue.trim()
+    }
     // Remove if empty
     if (!node.nodeValue.length) {
       node.remove()

--- a/packages/svgcanvas/core/svg-exec.js
+++ b/packages/svgcanvas/core/svg-exec.js
@@ -138,9 +138,11 @@ const svgToString = (elem, indent) => {
     cleanupElement(elem)
     const attrs = [...elem.attributes]
     const childs = elem.childNodes
-    attrs.sort((a, b) => {
-      return a.name > b.name ? -1 : 1
-    })
+
+    // Do not sort attributes!
+    // attrs.sort((a, b) => {
+    //   return a.name > b.name ? -1 : 1
+    // })
 
     for (let i = 0; i < indent; i++) {
       out.push(' ')
@@ -250,7 +252,8 @@ const svgToString = (elem, indent) => {
       }
 
       const mozAttrs = ['-moz-math-font-style', '_moz-math-font-style']
-      for (let i = attrs.length - 1; i >= 0; i--) {
+      // Do not iterate attributes in reverse order!
+      for (let i = 0; i < attrs.length; i++) {
         const attr = attrs[i]
         let attrVal = toXml(attr.value)
         // remove bogus attributes added by Gecko
@@ -265,6 +268,7 @@ const svgToString = (elem, indent) => {
             continue
           }
         }
+
         if (attrVal !== '') {
           if (attrVal.startsWith('pointer-events')) {
             continue
@@ -276,7 +280,8 @@ const svgToString = (elem, indent) => {
           if (attr.localName === 'd') {
             attrVal = svgCanvas.pathActions.convertPath(elem, true)
           }
-          if (!isNaN(attrVal)) {
+          // Properly parse attribute value if it is a number!
+          if (!isNaN(attrVal) && !isNaN(parseFloat(attrVal))) {
             attrVal = shortFloat(attrVal)
           } else if (unitRe.test(attrVal)) {
             attrVal = shortFloat(attrVal) + unit
@@ -308,6 +313,23 @@ const svgToString = (elem, indent) => {
             out.push(attrVal)
             out.push('"')
           }
+        } else {
+          // Do not skip data attribute even they are empty!
+          if ((/^data[-]/i).test(attr.localName)) {
+            // map various namespaces to our fixed namespace prefixes
+            // (the default xmlns attribute itself does not get a prefix)
+            if (
+              !attr.namespaceURI ||
+              attr.namespaceURI === NS.SVG ||
+              nsMap[attr.namespaceURI]
+            ) {
+              out.push(' ')
+              out.push(attr.nodeName)
+              out.push('="')
+              out.push(attrVal)
+              out.push('"')
+            }
+          }
         }
       }
     }
@@ -326,7 +348,11 @@ const svgToString = (elem, indent) => {
             break
           case 3: {
             // text node
-            const str = child.nodeValue.replace(/^\s+|\s+$/g, '')
+            let str = child.nodeValue
+            // Do not trim values of <text> tags, they may have xml:space="preserve" attribute".
+            if (child.parentElement?.nodeName !== 'text') {
+              str = child.nodeValue.replace(/^\s+|\s+$/g, '')
+            }
             if (str !== '') {
               bOneLine = true
               out.push(String(toXml(str)))
@@ -628,6 +654,7 @@ const setSvgString = (xmlString, preventUndo) => {
  * @function module:svgcanvas.SvgCanvas#importSvgString
  * @param {string} xmlString - The SVG as XML text.
  * @param {boolean} preserveDimension - A boolean to force to preserve initial dimension of the imported svg (force svgEdit don't apply a transformation on the imported svg)
+ * @param {boolean} doNotUseExisting - Do not use existing imported elements.
  * @fires module:svgcanvas.SvgCanvas#event:changed
  * @returns {null|Element} This function returns null if the import was unsuccessful, or the element otherwise.
  * @todo
@@ -637,7 +664,7 @@ const setSvgString = (xmlString, preventUndo) => {
  * arbitrary transform lists, but makes some assumptions about how the transform list
  * was obtained
  */
-const importSvgString = (xmlString, preserveDimension) => {
+const importSvgString = (xmlString, preserveDimension, doNotUseExisting) => {
   const dataStorage = svgCanvas.getDataStorage()
   let j
   let ts
@@ -645,7 +672,6 @@ const importSvgString = (xmlString, preserveDimension) => {
   try {
     // Get unique ID
     const uid = hashCode(xmlString)
-
     let useExisting = false
     // Look for symbol and make sure symbol exists in image
     if (svgCanvas.getImportIds(uid) && svgCanvas.getImportIds(uid).symbol) {
@@ -657,7 +683,7 @@ const importSvgString = (xmlString, preserveDimension) => {
 
     const batchCmd = new BatchCommand('Import Image')
     let symbol
-    if (useExisting) {
+    if (useExisting && !doNotUseExisting) {
       symbol = svgCanvas.getImportIds(uid).symbol
       ts = svgCanvas.getImportIds(uid).xform
     } else {
@@ -1290,14 +1316,14 @@ const convertGradientsMethod = elem => {
             (tmpFillStrokeElems[0].tagName === 'linearGradient' ||
               tmpFillStrokeElems[0].tagName === 'radialGradient') &&
             tmpFillStrokeElems[0].getAttribute('gradientUnits') ===
-              'userSpaceOnUse'
+            'userSpaceOnUse'
           ) {
             fillStrokeElems = svgContent.querySelectorAll(
               '[fill="url(#' +
-                tmpFillStrokeElems[0].id +
-                ')"],[stroke="url(#' +
-                tmpFillStrokeElems[0].id +
-                ')"]'
+              tmpFillStrokeElems[0].id +
+              ')"],[stroke="url(#' +
+              tmpFillStrokeElems[0].id +
+              ')"]'
             )
           } else {
             return


### PR DESCRIPTION
## PR description

Do not sort attributes!
Do not iterate attributes in reverse order!
Properly parse attribute value if it is a number!
Do not skip data attribute even they are empty!
Do not trim spaces of <text> elements.
Option not to use existing imported elements.
Expand SVG whitelist


## Checklist

Note that we require UI tests to ensure that the added feature will not be
nixed by some future fix and that there is at least some test-as-documentation
to indicate how the fix or enhancement is expected to behave.

- [ ] - Added Cypress UI tests
- [ ] - Ran `npm test`, ensuring linting passes and that Cypress UI tests keep
        coverage to at least the same percent (reflected in the coverage badge
        that should be updated after the tests run)
- [ ] - Added any user documentation. Though not required, this can be a big
        help both for future users and for the PR reviewer.

## Summary by Sourcery

Preserve SVG markup fidelity and support configuration-driven attributes when serializing and sanitizing SVG, while adding control over reuse of previously imported symbols.

New Features:
- Add a flag to importSvgString to optionally avoid reusing previously imported SVG symbols.
- Preserve empty data-* attributes when serializing SVG elements.
- Allow alignment-baseline on text and tspan elements through the SVG sanitizer whitelist.

Bug Fixes:
- Stop sorting or reverse-iterating SVG attributes so their original order and semantics are preserved.
- Ensure numeric SVG attribute values are correctly detected and shortened without corrupting non-numeric values.
- Avoid trimming whitespace in text node content under <text> elements during serialization and sanitization to respect xml:space="preserve".