### PR TITLE
fix(editor): Preserve closed-path Z command when moving a path (#1093)

### DIFF
--- a/packages/svgcanvas/core/coords.js
+++ b/packages/svgcanvas/core/coords.js
@@ -63,6 +63,10 @@ const pathMap = [
   0, 'z', 'M', 'm', 'L', 'l', 'C', 'c', 'Q', 'q', 'A', 'a', 'H', 'h', 'V', 'v', 'S', 's', 'T', 't'
 ]
 
+// ClosePath has no separate absolute/relative command, so pathMap only
+// lists the lowercase 'z'; derive its type rather than hardcoding it.
+const CLOSEPATH_TYPE = pathMap.indexOf('z')
+
 /**
  * Applies coordinate changes to an element based on the given matrix.
  * @function module:coords.remapElement
@@ -311,9 +315,7 @@ export const remapElement = (selected, changes, m) => {
         for (let i = 0; i < len; ++i) {
           const seg = pathDataSegments[i]
           const t = seg.type
-          // ClosePath has no separate absolute/relative command, so pathMap
-          // only lists the lowercase 'z'; normalize 'Z' to it here.
-          const type = t === 'Z' ? pathMap.indexOf('z') : pathMap.indexOf(t)
+          const type = t === 'Z' ? CLOSEPATH_TYPE : pathMap.indexOf(t)
           if (type === -1) continue
           const values = seg.values || []
           const entry = { type }
@@ -439,7 +441,7 @@ export const remapElement = (selected, changes, m) => {
         const letter = pathMap[type]
         dstr += letter
         switch (type) {
-          case 1: // closepath (Z/z)
+          case CLOSEPATH_TYPE: // closepath (Z/z)
             newPathData.push({ type: letter, values: [] })
             break
           case 13: // relative horizontal line (h)

--- a/packages/svgcanvas/core/coords.js
+++ b/packages/svgcanvas/core/coords.js
@@ -311,7 +311,9 @@ export const remapElement = (selected, changes, m) => {
         for (let i = 0; i < len; ++i) {
           const seg = pathDataSegments[i]
           const t = seg.type
-          const type = pathMap.indexOf(t)
+          // ClosePath has no separate absolute/relative command, so pathMap
+          // only lists the lowercase 'z'; normalize 'Z' to it here.
+          const type = t === 'Z' ? pathMap.indexOf('z') : pathMap.indexOf(t)
           if (type === -1) continue
           const values = seg.values || []
           const entry = { type }
@@ -437,6 +439,9 @@ export const remapElement = (selected, changes, m) => {
         const letter = pathMap[type]
         dstr += letter
         switch (type) {
+          case 1: // closepath (Z/z)
+            newPathData.push({ type: letter, values: [] })
+            break
           case 13: // relative horizontal line (h)
           case 12: // absolute horizontal line (H)
             dstr += `${seg.x} `

--- a/tests/unit/coords.test.js
+++ b/tests/unit/coords.test.js
@@ -856,6 +856,59 @@ describe('coords', function () {
     assert.ok(true)
   })
 
+  it('Test remapElement(translate) for closed path (uppercase Z)', function () {
+    const path = document.createElementNS(NS.SVG, 'path')
+    path.setAttribute('d', 'M10,10 L50,10 L50,50 Z')
+    svg.append(path)
+
+    const m = svg.createSVGMatrix()
+    m.a = 1; m.b = 0
+    m.c = 0; m.d = 1
+    m.e = 100; m.f = -50
+
+    coords.remapElement(path, {}, m)
+
+    const d = path.getAttribute('d')
+    assert.match(d, /[Zz]\s*$/, `Expected closed path to keep close command, got: ${d}`)
+    assert.match(d, /M\s*110,-40/, `Expected start point to be translated, got: ${d}`)
+  })
+
+  it('Test remapElement(translate) for closed path via native getPathData/setPathData (uppercase Z)', function () {
+    // Simulate a browser (e.g. Firefox) that implements the native
+    // getPathData()/setPathData() API, where the close-path segment's
+    // `type` is reported as uppercase 'Z' rather than lowercase 'z'.
+    const path = document.createElementNS(NS.SVG, 'path')
+    path.setAttribute('d', 'M10,10 L50,10 L50,50 Z')
+    svg.append(path)
+
+    const parsedPathData = [
+      { type: 'M', values: [10, 10] },
+      { type: 'L', values: [50, 10] },
+      { type: 'L', values: [50, 50] },
+      { type: 'Z', values: [] }
+    ]
+    path.getPathData = () => parsedPathData
+    let setPathDataArg = null
+    path.setPathData = (data) => { setPathDataArg = data }
+
+    const m = svg.createSVGMatrix()
+    m.a = 1; m.b = 0
+    m.c = 0; m.d = 1
+    m.e = 100; m.f = -50
+
+    // Should not throw destructuring 'type' off an undefined segment.
+    assert.doesNotThrow(() => coords.remapElement(path, {}, m))
+
+    const d = path.getAttribute('d')
+    assert.match(d, /[Zz]\s*$/, `Expected closed path to keep close command, got: ${d}`)
+    assert.match(d, /M\s*110,-40/, `Expected start point to be translated, got: ${d}`)
+
+    // The close-path segment must be preserved in the data passed to setPathData too.
+    assert.ok(setPathDataArg, 'Expected setPathData to be called')
+    const lastSeg = setPathDataArg[setPathDataArg.length - 1]
+    assert.equal(lastSeg.type.toUpperCase(), 'Z')
+  })
+
   it('Test remapElement with path d attribute update', function () {
     const path = document.createElementNS(NS.SVG, 'path')
     path.setAttribute('d', 'M 10,10 L 20,20')

--- a/tests/unit/coords.test.js
+++ b/tests/unit/coords.test.js
@@ -887,7 +887,7 @@ describe('coords', function () {
       { type: 'L', values: [50, 50] },
       { type: 'Z', values: [] }
     ]
-    path.getPathData = () => parsedPathData
+    path.getPathData = () => parsedPathData.map(seg => ({ type: seg.type, values: [...seg.values] }))
     let setPathDataArg = null
     path.setPathData = (data) => { setPathDataArg = data }
 


### PR DESCRIPTION
## Summary
- Fixes #1093: moving a closed shape drawn with the path tool caused it to snap back to its original position (Firefox specifically), with a console error like `Cannot destructure property 'type' of undefined`.
- Root cause: `remapElement()`'s native `getPathData()` branch in `packages/svgcanvas/core/coords.js` maps each path segment's letter (`M`, `L`, `Z`, ...) to a numeric type via `pathMap.indexOf(t)`. `pathMap` only lists the lowercase `'z'` for the close-path command, but paths serialize the close command as uppercase `'Z'`. The lookup returned `-1`, leaving a hole in the segment array; a later loop destructured `type` off that hole and threw, aborting the move before the new geometry was committed. This only reproduces in browsers with native `getPathData`/`setPathData` support (e.g. Firefox) — Chrome falls back to the legacy `pathSegList` API, which uses numeric constants instead of letters and isn't affected, matching what's reported in the issue thread.
- Also fixed a related latent bug in the same function: the `newPathData` builder had no case for the close-path segment type, so even after the crash is fixed, calling `setPathData()` would silently drop the `Z` and reopen the shape.

## Test plan
- [x] Added a regression test in `tests/unit/coords.test.js` that stubs `getPathData`/`setPathData` on a closed path (simulating Firefox) and verifies the move no longer throws and the closed shape (and its `Z` command) is preserved.
- [x] Verified the new test reproduces the exact reported error when the fix is reverted.
- [x] `npx vitest run tests/unit` — 569 tests pass.
- [x] `npx standard` — no lint errors on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Preserve closed SVG paths when remapping elements so translated shapes remain closed across browsers.

Bug Fixes:
- Ensure remapElement correctly handles uppercase close-path commands from native getPathData/setPathData so closed shapes no longer revert or throw errors when moved.
- Include close-path segments when rebuilding path data so moving a closed path does not drop its closing command and reopen the shape.

Tests:
- Add regression tests covering remapElement translation of closed paths, including a simulated native getPathData/setPathData environment, to verify the close-path command is preserved and no errors are thrown.