### PR TITLE
fix: correct engines.node to match vite/rolldown's actual requirement

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -11583,6 +11583,9 @@
       },
       "devDependencies": {
         "@babel/preset-react": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "packages/react-test/node_modules/@babel/code-frame": {
@@ -11979,7 +11982,10 @@
     "packages/svgcanvas": {
       "name": "@svgedit/svgcanvas",
       "version": "7.4.2",
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,7 @@
         "vitest": "^4.1.10"
       },
       "engines": {
-        "node": ">=20"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
         "@rollup/rollup-linux-x64-gnu": "4.62.2"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "test": "test"
   },
   "engines": {
-    "node": ">=20"
+    "node": "^20.19.0 || >=22.12.0"
   },
   "workspaces": [
     "packages/svgcanvas",

--- a/packages/react-test/package.json
+++ b/packages/react-test/package.json
@@ -30,6 +30,9 @@
   },
   "author": "OptimistikSAS",
   "license": "MIT",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "dependencies": {
     "react": "^19.2.7",
     "react-dom": "^19.2.7"

--- a/packages/svgcanvas/package.json
+++ b/packages/svgcanvas/package.json
@@ -33,6 +33,9 @@
     "svgcanvas"
   ],
   "license": "MIT",
+  "engines": {
+    "node": "^20.19.0 || >=22.12.0"
+  },
   "browserslist": [
     "defaults",
     "not IE 11",


### PR DESCRIPTION
## Summary
- Fixes #1102 — build fails with `SyntaxError: The requested module 'node:util' does not provide an export named 'styleText'`
- Root cause: `vite@8`/`rolldown` require Node `^20.19.0 || >=22.12.0` (confirmed in their own `package.json` `engines` fields — they use `node:util`'s `styleText`, which isn't available on earlier Node 20.x, 21.x, or early 22.x releases). Our root `package.json` only required `>=20`, so unsupported versions (e.g. Node 21.0.0, as in the reporter's Docker repro) passed the engine check and only failed later with a confusing low-level rolldown crash.
- Corrected `engines.node` to `^20.19.0 || >=22.12.0` and regenerated the lockfile to match.
- Added `.npmrc` with `engine-strict=true` so `npm install` now fails fast with a clear "Unsupported engine" message on an incompatible Node version, instead of letting the build fail later with a cryptic error.

## Test plan
- [x] `npm install` succeeds on Node v24.18.0 (satisfies the new range)
- [x] `npm run build --workspace @svgedit/svgcanvas` builds successfully
- [x] Verified `vite`/`rolldown`'s own `engines` fields in `node_modules` to confirm the correct minimum version range

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Tighten Node.js engine requirements to align with vite/rolldown and enforce early failure on unsupported Node versions.

Build:
- Update root package.json Node engine range to ^20.19.0 || >=22.12.0 to match vite/rolldown requirements.
- Regenerate package-lock.json to reflect the updated engine constraints and dependency resolution.
- Add an .npmrc with engine-strict=true so npm install fails fast on incompatible Node versions.